### PR TITLE
Completely new, updated, and more rigorous publication list

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,60 +1,1220 @@
+@ARTICLE{2026MNRAS.548ag650S,
+       author = {{Somerville}, Rachel S. and {Gabrielpillai}, Austen and {Hadzhiyska}, Boryana and {Genel}, Shy},
+        title = "{The relationship between galaxy size and halo properties: insights from the IllustrisTNG simulations and differential clustering}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Galaxy: evolution, Galaxy: formation, Astrophysics - Astrophysics of Galaxies},
+         year = 2026,
+        month = jun,
+       volume = {548},
+       number = {4},
+          eid = {stag650},
+        pages = {stag650},
+          doi = {10.1093/mnras/stag650},
+archivePrefix = {arXiv},
+       eprint = {2502.03679},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026MNRAS.548ag650S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026ApJ..1003..170S,
+       author = {{Sommovigo}, Laura and {Lancaster}, Lachlan and {Menon}, Shyam H. and {O'Leary}, Joseph A. and {Somerville}, Rachel S. and {Bryan}, Greg L.},
+        title = "{Blue Monsters and Dusty Descendants: Reconciling UV and IR Emission from Galaxies from z {\ensuremath{\sim}} 7, up to z = 14}",
+      journal = {The Astrophysical Journal},
+     keywords = {Theoretical models, Interstellar dust, 2107, 836, Astrophysics of Galaxies},
+         year = 2026,
+        month = jun,
+       volume = {1003},
+       number = {2},
+          eid = {170},
+        pages = {170},
+          doi = {10.3847/1538-4357/ae5e58},
+archivePrefix = {arXiv},
+       eprint = {2602.18556},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ..1003..170S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260518987M,
+       author = {{Messere}, Michael and {Bryan}, Greg L.},
+        title = "{How High-Specific-Energy Winds Regulate the Circumgalactic Medium of Dwarf Galaxies}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics of Galaxies},
+         year = 2026,
+        month = may,
+          eid = {arXiv:2605.18987},
+        pages = {arXiv:2605.18987},
+          doi = {10.48550/arXiv.2605.18987},
+archivePrefix = {arXiv},
+       eprint = {2605.18987},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260518987M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260503154S,
+       author = {{Sullivan}, James M. and {Bryan}, Greg L. and {Smith}, Matthew C. and {Bennett}, Jake S. and {Fielding}, Drummond B. and {Terrazas}, Bryan A. and {Koudmani}, Sophie and {Somerville}, Rachel S. and {Hirschmann}, Michaela},
+        title = "{ArkenstoneBH. A model for high-specific energy black hole feedback in cosmological simulations}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics of Galaxies},
+         year = 2026,
+        month = may,
+          eid = {arXiv:2605.03154},
+        pages = {arXiv:2605.03154},
+          doi = {10.48550/arXiv.2605.03154},
+archivePrefix = {arXiv},
+       eprint = {2605.03154},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260503154S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026ApJ..1003...97P,
+       author = {{Porter}, Lori E. and {Jeffreson}, S.~M.~R. and {Bryan}, Greg L. and {Hernquist}, Lars},
+        title = "{What Suppresses Star Formation in Bulge-dominated Early-type Galaxies?}",
+      journal = {The Astrophysical Journal},
+     keywords = {Quenched galaxies, Galaxies, Galaxy quenching, Galaxy evolution, Early-type galaxies, Interstellar medium, Galaxy processes, Galaxy dynamics, 2016, 573, 2040, 594, 429, 847, 614, 591, Astrophysics of Galaxies},
+         year = 2026,
+        month = may,
+       volume = {1003},
+       number = {1},
+          eid = {97},
+        pages = {97},
+          doi = {10.3847/1538-4357/ae5f92},
+archivePrefix = {arXiv},
+       eprint = {2602.12324},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ..1003...97P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260417981L,
+       author = {{Lovell}, Christopher C. and {Lee}, Max E. and {Roper}, William J. and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Genel}, Shy and {Pandey}, Shivam and {Villaescusa-Navarro}, Francisco},
+        title = "{Efficiently emulating distribution functions in gigaparsec volumes for varying cosmological parameters}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2026,
+        month = apr,
+          eid = {arXiv:2604.17981},
+        pages = {arXiv:2604.17981},
+archivePrefix = {arXiv},
+       eprint = {2604.17981},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260417981L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260406318P,
+       author = {{Pandya}, Viraj and {Bryan}, Greg L. and {Makinen}, T. Lucas and {Gabrielpillai}, Austen and {Carr}, Christopher and {Fielding}, Drummond B. and {Hernquist}, Lars and {Ho}, Matthew and {Iyer}, Kartheik and {Jespersen}, Christian Kragh and {Koudmani}, Sophie and {Laska}, Marta and {Lemos}, Pablo and {Lovell}, Christopher C. and {Perez}, Lucia A. and {Robinson}, Jr., William F. and {Somerville}, Rachel S. and {Starkenburg}, Tjitske K. and {Stiskalek}, Richard and {Terrazas}, Bryan and {Voit}, G. Mark},
+        title = "{Introducing sapphire: Towards Hybrid Physics-Informed, Data-Driven Modeling of Galaxy Formation}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics of Galaxies},
+         year = 2026,
+        month = apr,
+          eid = {arXiv:2604.06318},
+        pages = {arXiv:2604.06318},
+          doi = {10.48550/arXiv.2604.06318},
+archivePrefix = {arXiv},
+       eprint = {2604.06318},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260406318P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  selected = {true}
+}
+
+@ARTICLE{2026MNRAS.547ag374B,
+       author = {{Bennett}, Jake S. and {Smith}, Matthew C. and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Kim}, Chang-Goo and {Springel}, Volker and {Hernquist}, Lars and {Somerville}, Rachel S. and {Sommovigo}, Laura},
+        title = "{Correction to: Prevention is better than cure? Feedback from high specific energy winds in cosmological simulations with ARKENSTONE}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {errata, addenda, hydrodynamics, methods: numerical, galaxies: evolution, galaxies: formation},
+         year = 2026,
+        month = apr,
+       volume = {547},
+       number = {2},
+          eid = {stag374},
+        pages = {stag374},
+          doi = {10.1093/mnras/stag374},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026MNRAS.547ag374B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260311815L,
+       author = {{Lee}, Max E. and {Haiman}, Zoltan and {Genel}, Shy},
+        title = "{The impact of baryons on weak lensing statistics as a function of halo mass and radius}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2026,
+        month = mar,
+          eid = {arXiv:2603.11815},
+        pages = {arXiv:2603.11815},
+          doi = {10.48550/arXiv.2603.11815},
+archivePrefix = {arXiv},
+       eprint = {2603.11815},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260311815L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260304535S,
+       author = {{Sotoudeh}, Hadi and {Lemos}, Pablo and {Perreault-Levasseur}, Laurence},
+        title = "{A Fast Generative Framework for High-dimensional Posterior Sampling: Application to CMB Delensing}",
+      journal = {arXiv e-prints},
+     keywords = {Instrumentation and Methods for Astrophysics, Cosmology and Nongalactic Astrophysics, Machine Learning, 62F15, 68T07, 62P35, I.2.6; G.3; I.4.9},
+         year = 2026,
+        month = mar,
+          eid = {arXiv:2603.04535},
+        pages = {arXiv:2603.04535},
+          doi = {10.48550/arXiv.2603.04535},
+archivePrefix = {arXiv},
+       eprint = {2603.04535},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260304535S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026JCAP...03..028B,
+       author = {{Bairagi}, Anirban and {Wandelt}, Benjamin},
+        title = "{PATCHNET: A hierarchical approach for neural field-level inference from Quijote simulations}",
+      journal = {Journal of Cosmology and Astroparticle Physics},
+     keywords = {cosmological parameters from LSS, Machine learning, Bayesian reasoning, cosmological simulations, Cosmology and Nongalactic Astrophysics, Information Theory},
+         year = 2026,
+        month = mar,
+       volume = {2026},
+       number = {3},
+          eid = {028},
+        pages = {028},
+          doi = {10.1088/1475-7516/2026/03/028},
+archivePrefix = {arXiv},
+       eprint = {2509.03165},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026JCAP...03..028B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  selected = {true}
+}
+
+@ARTICLE{2026ApJS..283...37Z,
+       author = {{Zhao}, Xihui and {Bai}, Xue-Ning and {Ostriker}, Eve C.},
+        title = "{Cosmic-ray Magnetohydrodynamics: A New Two-moment Framework with Numerical Implementation}",
+      journal = {The Astrophysical Journal Supplement Series},
+     keywords = {Cosmic rays, Cosmic ray astronomy, Computational methods, Magnetohydrodynamics, Plasma astrophysics, Interstellar medium, Circumgalactic medium, Perturbation methods, 329, 324, 1965, 1964, 1261, 847, 1879, 1215, High Energy Astrophysical Phenomena, Astrophysics of Galaxies},
+         year = 2026,
+        month = mar,
+       volume = {283},
+       number = {1},
+          eid = {37},
+        pages = {37},
+          doi = {10.3847/1538-4365/ae3e7f},
+archivePrefix = {arXiv},
+       eprint = {2509.04387},
+ primaryClass = {astro-ph.HE},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJS..283...37Z},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260204987P,
+       author = {{Perez}, Lucia A. and {Genel}, Shy and {Krause}, Elisabeth and {Somerville}, Rachel S.},
+        title = "{The Impact of Galaxy Formation on Galaxy Biasing, and Implications for Primordial non-Gaussianity Constraints}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2026,
+        month = feb,
+          eid = {arXiv:2602.04987},
+        pages = {arXiv:2602.04987},
+          doi = {10.48550/arXiv.2602.04987},
+archivePrefix = {arXiv},
+       eprint = {2602.04987},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260204987P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  selected = {true}
+}
+
+@ARTICLE{2026arXiv260202363A,
+       author = {{Andrews}, Adam and {Loureiro}, Arthur and {Jasche}, Jens and {McAlpine}, Stuart and {Lavaux}, Guilhem and {Leclercq}, Florent},
+        title = "{Reconstructing the largest scales of the Universe with field-level inference applied to the Quaia Quasar Catalogue}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics},
+         year = 2026,
+        month = feb,
+          eid = {arXiv:2602.02363},
+        pages = {arXiv:2602.02363},
+          doi = {10.48550/arXiv.2602.02363},
+archivePrefix = {arXiv},
+       eprint = {2602.02363},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260202363A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026OJAp....957824S,
+       author = {{Stiskalek}, Richard and {Desmond}, Harry and {McAlpine}, Stuart and {Lavaux}, Guilhem and {Jasche}, Jens and {Hudson}, Michael J.},
+        title = "{Revisiting the Great Attractor: The Local Group's streamline trajectory, cosmic velocity and dynamical fate}",
+      journal = {The Open Journal of Astrophysics},
+         year = 2026,
+        month = feb,
+       volume = {9},
+        pages = {57824},
+          doi = {10.33232/001c.157824},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026OJAp....957824S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026MNRAS.546f2260S,
+       author = {{Stiskalek}, Richard and {Desmond}, Harry and {Tsaprazi}, Eleni and {Heavens}, Alan and {Lavaux}, Guilhem and {McAlpine}, Stuart and {Jasche}, Jens},
+        title = "{1.8 per cent measurement of H$_{0}$ from Cepheids alone}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {galaxies: distances and redshifts, cosmological parameters, distance scale, Cosmology and Nongalactic Astrophysics},
+         year = 2026,
+        month = feb,
+       volume = {546},
+       number = {2},
+          eid = {staf2260},
+        pages = {staf2260},
+          doi = {10.1093/mnras/staf2260},
+archivePrefix = {arXiv},
+       eprint = {2509.09665},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026MNRAS.546f2260S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026MNRAS.546f2048S,
+       author = {{Stiskalek}, Richard and {Desmond}, Harry and {Lavaux}, Guilhem},
+        title = "{No evidence for local H$_{0}$ anisotropy from Tully─Fisher or supernova distances}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {galaxies: distances and redshifts, distance scale, large-scale structure of the universe, Cosmology and Nongalactic Astrophysics},
+         year = 2026,
+        month = feb,
+       volume = {546},
+       number = {2},
+          eid = {staf2048},
+        pages = {staf2048},
+          doi = {10.1093/mnras/staf2048},
+archivePrefix = {arXiv},
+       eprint = {2509.14997},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026MNRAS.546f2048S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026ApJ...998..329S,
+       author = {{Sui}, Ce and {Mao}, Yi and {Zhao}, Xiaosheng and {Jing}, Tao and {Wandelt}, Benjamin D.},
+        title = "{How to Evaluate the Sufficiency and Complementarity of Summary Statistics for Cosmic Fields: An Information-theoretic Perspective}",
+      journal = {The Astrophysical Journal},
+     keywords = {Cosmology, Fisher's Information, Bayesian statistics, 343, 1922, 1900, Cosmology and Nongalactic Astrophysics, Instrumentation and Methods for Astrophysics},
+         year = 2026,
+        month = feb,
+       volume = {998},
+       number = {2},
+          eid = {329},
+        pages = {329},
+          doi = {10.3847/1538-4357/ae3aa4},
+archivePrefix = {arXiv},
+       eprint = {2511.08716},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ...998..329S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026ApJ...998..238J,
+       author = {{Jo}, Yongseok and {Genel}, Shy and {Leja}, Joel and {Wandelt}, Benjamin},
+        title = "{On the Significance of Covariance for Constraining Theoretical Models from Galaxy Observables}",
+      journal = {The Astrophysical Journal},
+     keywords = {Observational astronomy, Cosmological parameters, Galaxy mass distribution, Astronomical simulations, 1145, 339, 606, 1857, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+         year = 2026,
+        month = feb,
+       volume = {998},
+       number = {2},
+          eid = {238},
+        pages = {238},
+          doi = {10.3847/1538-4357/ae19e4},
+archivePrefix = {arXiv},
+       eprint = {2410.21722},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ...998..238J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  selected = {true}
+}
+
+@ARTICLE{2026ApJ...997..187B,
+       author = {{Bhowmick}, Aklant K. and {Blecha}, Laura and {Torrey}, Paul and {Kelley}, Luke Zoltan and {Natarajan}, Priyamvada and {Somerville}, Rachel S. and {Weinberger}, Rainer and {Garcia}, Alex M. and {Hernquist}, Lars and {Di Matteo}, Tiziana and {Kho}, Jonathan and {Vogelsberger}, Mark},
+        title = "{Heavy Seeds and the First Black Holes: Insights from the BRAHMA Simulations}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galaxy formation, Supermassive black holes, Active galactic nuclei, Hydrodynamical simulations, 595, 1663, 16, 767, Astrophysics of Galaxies},
+         year = 2026,
+        month = feb,
+       volume = {997},
+       number = {2},
+          eid = {187},
+        pages = {187},
+          doi = {10.3847/1538-4357/ae2607},
+archivePrefix = {arXiv},
+       eprint = {2510.01322},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ...997..187B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026arXiv260108524S,
+       author = {{Stiskalek}, Richard and {Desmond}, Harry and {McAlpine}, Stuart and {Lavaux}, Guilhem and {Jasche}, Jens and {Hudson}, Michael J.},
+        title = "{Revisiting the Great Attractor: The Local Group's streamline trajectory, cosmic velocity and dynamical fate}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2026,
+        month = jan,
+          eid = {arXiv:2601.08524},
+        pages = {arXiv:2601.08524},
+          doi = {10.48550/arXiv.2601.08524},
+archivePrefix = {arXiv},
+       eprint = {2601.08524},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260108524S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2026ApJ...996...36L,
+       author = {{Lee}, Max E. and {Haiman}, Zolt{\'a}n and {Pandey}, Shivam and {Genel}, Shy},
+        title = "{The Effect of Intrinsic Alignments on Weak-lensing Statistics in Hydrodynamical Simulations}",
+      journal = {The Astrophysical Journal},
+     keywords = {Weak gravitational lensing, Hydrodynamical simulations, Large-scale structure of the universe, 1797, 767, 902, Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2026,
+        month = jan,
+       volume = {996},
+       number = {1},
+          eid = {36},
+        pages = {36},
+          doi = {10.3847/1538-4357/ae1ca7},
+archivePrefix = {arXiv},
+       eprint = {2504.12460},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ApJ...996...36L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Malandrino:2025,
+       author = {{Malandrino}, R. and {Lavaux}, G. and {Wandelt}, B.~D. and {McAlpine}, S. and {Jasche}, J.},
+        title = "{A Bayesian catalog of 100 high-significance voids in the Local Universe}",
+      journal = {Astronomy and Astrophysics},
+     keywords = {methods: numerical, methods: statistical, catalogs, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics},
+         year = 2026,
+        month = jan,
+       volume = {705},
+          eid = {A160},
+        pages = {A160},
+          doi = {10.1051/0004-6361/202556345},
+archivePrefix = {arXiv},
+       eprint = {2507.06866},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026A&A...705A.160M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{lovell2024learninguniversecosmologicalastrophysical,
-       author = {{Lovell}, Christopher C. and {Starkenburg}, Tjitske and {Ho}, Matthew and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Dav{\'e}}, Romeel and {Gabrielpillai}, Austen and {Iyer}, Kartheik and {Matthews}, Alice E. and {Roper}, William J. and {Somerville}, Rachel and {Sommovigo}, Laura and {Villaescusa-Navarro}, Francisco},
-        title = "{Learning the Universe: Cosmological and Astrophysical Parameter Inference with Galaxy Luminosity Functions and Colours}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = nov,
-          eid = {arXiv:2411.13960},
-        pages = {arXiv:2411.13960},
-          doi = {10.48550/arXiv.2411.13960},
+       author = {{Lovell}, Christopher C. and {Starkenburg}, Tjitske and {Ho}, Matthew and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Dav{\'e}}, Romeel and {Gabrielpillai}, Austen and {Iyer}, Kartheik G. and {Matthews}, Alice E. and {Roper}, William J. and {Somerville}, Rachel S. and {Sommovigo}, Laura and {Villaescusa-Navarro}, Francisco},
+        title = "{Learning the Universe: cosmological and astrophysical parameter inference with galaxy luminosity functions and colours}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {galaxies: abundances, galaxies: evolution, galaxies: photometry, cosmological parameters, Astrophysics of Galaxies, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = dec,
+       volume = {544},
+       number = {4},
+        pages = {3949-3979},
+          doi = {10.1093/mnras/staf1888},
 archivePrefix = {arXiv},
        eprint = {2411.13960},
  primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv241113960L},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.544.3949L},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2025MNRAS.544.1390B,
+       author = {{Burger}, Jan D. and {Springel}, Volker and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Jeffreson}, Sarah M.~R. and {Smith}, Matthew C. and {Pakmor}, R{\"u}diger and {Hassan}, Sultan and {Fielding}, Drummond and {Hernquist}, Lars and {Bryan}, Greg L. and {Somerville}, Rachel S. and {Bennett}, Jake S. and {Weinberger}, Rainer},
+        title = "{Applying a star formation model calibrated on high-resolution interstellar medium simulations to cosmological simulations of galaxy formation}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {methods: numerical, galaxies: haloes, dark matter, large-scale structure of Universe, cosmology: theory, Astrophysics of Galaxies},
+         year = 2025,
+        month = dec,
+       volume = {544},
+       number = {2},
+        pages = {1390-1411},
+          doi = {10.1093/mnras/staf1720},
+archivePrefix = {arXiv},
+       eprint = {2502.13244},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.544.1390B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  selected = {true}
+}
 
+@ARTICLE{2025ApJ...994..174I,
+       author = {{Iyer}, Kartheik G. and {Starkenburg}, Tjitske K. and {Bryan}, Greg L. and {Somerville}, Rachel S. and {Alfonzo}, Juan Pablo and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Cooray}, Suchetha and {Dav{\'e}}, Romeel and {Gabrielpillai}, Austen and {Genel}, Shy and {Hassan}, Sultan and {Hernquist}, Lars and {Jespersen}, Christian Kragh and {Lovell}, Christopher C. and {Oh}, Boon Kiat and {Pacifici}, Camilla and {Perez}, Lucia A. and {Sommovigo}, Laura and {Speagle}, Joshua S. and {Tacchella}, Sandro and {Tillman}, Megan T. and {Villaescusa-Navarro}, Francisco and {Wu}, John F.},
+        title = "{How Does Feedback Affect the Star Formation Histories of Galaxies?}",
+      journal = {The Astrophysical Journal},
+     keywords = {Astronomical simulations, Cosmology, Extragalactic astronomy, Galaxy physics, Star formation, Galactic winds, Stellar feedback, Supermassive black holes, 1857, 343, 506, 612, 1569, 572, 1602, 1663, Astrophysics of Galaxies, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = dec,
+       volume = {994},
+       number = {2},
+          eid = {174},
+        pages = {174},
+          doi = {10.3847/1538-4357/ae0334},
+archivePrefix = {arXiv},
+       eprint = {2508.21152},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...994..174I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
-@ARTICLE{2024arXiv240702574R,
-       author = {{Regos}, Eniko and {Springel}, Volker and {Bose}, Sownak and {Hadzhiyska}, Boryana and {Hernandez-Aguayo}, Cesar},
-        title = "{Percolation Statistics in the MillenniumTNG Simulations}",
+@ARTICLE{2025arXiv251111787H,
+       author = {{Hassan}, Sultan and {Andrianomena}, Sambatra and {Wandelt}, Benjamin D.},
+        title = "{Towards Mitigating Systematics in Large-Scale Surveys via Few-Shot Optimal Transport-Based Feature Alignment}",
       journal = {arXiv e-prints},
+     keywords = {Instrumentation and Methods for Astrophysics, Computer Vision and Pattern Recognition, Machine Learning},
+         year = 2025,
+        month = nov,
+          eid = {arXiv:2511.11787},
+        pages = {arXiv:2511.11787},
+          doi = {10.48550/arXiv.2511.11787},
+archivePrefix = {arXiv},
+       eprint = {2511.11787},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv251111787H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv251108438P,
+       author = {{Pandey}, Shivam and {Lovell}, Christopher C. and {Modi}, Chirag and {Wandelt}, Benjamin D.},
+        title = "{Galactification: painting galaxies onto dark matter only simulations using a transformer-based model}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Instrumentation and Methods for Astrophysics, Machine Learning},
+         year = 2025,
+        month = nov,
+          eid = {arXiv:2511.08438},
+        pages = {arXiv:2511.08438},
+          doi = {10.48550/arXiv.2511.08438},
+archivePrefix = {arXiv},
+       eprint = {2511.08438},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv251108438P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025PhRvD.112j3532H,
+       author = {{Hadzhiyska}, Boryana and {Sailer}, Noah and {Ferraro}, Simone},
+        title = "{Mapping the gas density with the kinematic Sunyaev-Zel'dovich and patchy screening effects: A self-consistent comparison}",
+      journal = {Physical Review D},
+     keywords = {Cosmology, Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2025,
+        month = nov,
+       volume = {112},
+       number = {10},
+          eid = {103532},
+        pages = {103532},
+          doi = {10.1103/xjst-ffw2},
+archivePrefix = {arXiv},
+       eprint = {2506.17379},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025PhRvD.112j3532H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240909124P,
+       author = {{Pandey}, Shivam and {Modi}, Chirag and {Wandelt}, Benjamin D. and {Bartlett}, Deaglan J. and {Bayer}, Adrian E. and {Bryan}, Greg L. and {Ho}, Matthew and {Lavaux}, Guilhem and {Makinen}, T. Lucas and {Villaescusa-Navarro}, Francisco},
+        title = "{Creating halos with autoregressive multistage networks}",
+      journal = {Physical Review D},
+     keywords = {Cosmology, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Statistics - Machine Learning},
+         year = 2025,
+        month = nov,
+       volume = {112},
+       number = {10},
+          eid = {103503},
+        pages = {103503},
+          doi = {10.1103/vlm2-tm6k},
+archivePrefix = {arXiv},
+       eprint = {2409.09124},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025PhRvD.112j3503P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025A&A...703A.301B,
+       author = {{Bairagi}, Anirban and {Wandelt}, Benjamin and {Villaescusa-Navarro}, Francisco},
+        title = "{The BIG SOBOL SEQUENCE: How many simulations do we need for simulation-based inference in cosmology?}",
+      journal = {Astronomy and Astrophysics},
+     keywords = {methods: statistical, cosmological parameters, dark matter, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics, Machine Learning},
+         year = 2025,
+        month = nov,
+       volume = {703},
+          eid = {A301},
+        pages = {A301},
+          doi = {10.1051/0004-6361/202554602},
+archivePrefix = {arXiv},
+       eprint = {2503.13755},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025A&A...703A.301B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv251018749B,
+       author = {{Bartlett}, Deaglan J. and {Pandey}, Shivam},
+        title = "{Symbolic Emulators for Cosmology: Accelerating Cosmological Analyses Without Sacrificing Precision}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Instrumentation and Methods for Astrophysics, Machine Learning, Neural and Evolutionary Computing},
+         year = 2025,
+        month = oct,
+          eid = {arXiv:2510.18749},
+        pages = {arXiv:2510.18749},
+          doi = {10.48550/arXiv.2510.18749},
+archivePrefix = {arXiv},
+       eprint = {2510.18749},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv251018749B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025MNRAS.543.1456B,
+       author = {{Bennett}, Jake S. and {Smith}, Matthew C. and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Kim}, Chang-Goo and {Springel}, Volker and {Hernquist}, Lars and {Somerville}, Rachel S. and {Sommovigo}, Laura},
+        title = "{Prevention is better than cure? Feedback from high specific energy winds in cosmological simulations with ARKENSTONE}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {hydrodynamics, methods: numerical, galaxies: evolution, galaxies: formation, Astrophysics of Galaxies, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = oct,
+       volume = {543},
+       number = {2},
+        pages = {1456-1478},
+          doi = {10.1093/mnras/staf1440},
+archivePrefix = {arXiv},
+       eprint = {2410.12909},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.543.1456B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Farcy2025,
+       author = {{Farcy}, Marion and {Hirschmann}, Michaela and {Somerville}, Rachel S. and {Choi}, Ena and {Koudmani}, Sophie and {Naab}, Thorsten and {Weinberger}, Rainer and {Bennett}, Jake S. and {Bhowmick}, Aklant K. and {Choi}, Hyunseop and {Hernquist}, Lars and {Hlavacek-Larrondo}, Julie and {Terrazas}, Bryan A. and {Valentino}, Francesco},
+        title = "{MISTRAL: a model for AGN winds from radiatively efficient accretion in cosmological simulations}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {methods: numerical, galaxies: active, galaxies: evolution, galaxies: formation, Astrophysics of Galaxies},
+         year = 2025,
+        month = oct,
+       volume = {543},
+       number = {2},
+        pages = {967-993},
+          doi = {10.1093/mnras/staf1464},
+archivePrefix = {arXiv},
+       eprint = {2504.08041},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.543..967F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025MNRAS.542.1403D,
+       author = {{Doeser}, Ludvig and {Ata}, Metin and {Jasche}, Jens},
+        title = "{Learning the Universe: learning to optimize cosmic initial conditions with non-differentiable structure formation models}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {software: machine learning, early Universe, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies, Machine Learning},
+         year = 2025,
+        month = sep,
+       volume = {542},
+       number = {2},
+        pages = {1403-1422},
+          doi = {10.1093/mnras/staf1289},
+archivePrefix = {arXiv},
+       eprint = {2502.13243},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.542.1403D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025MNRAS.542.1188P,
+       author = {{Porter}, Lori E. and {Abruzzo}, Matthew and {Bryan}, Greg L. and {Putman}, Mary and {Zheng}, Yong and {Fielding}, Drummond},
+        title = "{Simulating high-velocity clouds in the observational plane: an initial study with the Smith Cloud}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {methods: numerical, methods: observational, ISM: clouds, ISM: individual objects: Smith Cloud, Galaxy: halo, Galaxy: evolution, Astrophysics of Galaxies},
+         year = 2025,
+        month = sep,
+       volume = {542},
+       number = {2},
+        pages = {1188-1207},
+          doi = {10.1093/mnras/staf1288},
+archivePrefix = {arXiv},
+       eprint = {2506.00111},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.542.1188P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250213239J,
+       author = {{Jo}, Yongseok and {Genel}, Shy and {Sengupta}, Anirvan and {Wandelt}, Benjamin and {Somerville}, Rachel and {Villaescusa-Navarro}, Francisco},
+        title = "{Toward Robustness across Cosmological Simulation Models ILLUSTRISTNG, SIMBA, ASTRID, and SWIFT-EAGLE}",
+      journal = {The Astrophysical Journal},
+     keywords = {Cosmological parameters from large-scale structure, Cosmological parameters, Hydrodynamical simulations, Convolutional neural networks, Robust regression, Galaxy evolution, Cosmological evolution, 340, 339, 767, 1938, 1949, 594, 336, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = sep,
+       volume = {991},
+       number = {1},
+          eid = {120},
+        pages = {120},
+          doi = {10.3847/1538-4357/adec78},
+archivePrefix = {arXiv},
+       eprint = {2502.13239},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...991..120J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...991...16S,
+       author = {{Steinwandel}, Ulrich P. and {Rennehan}, Douglas and {Orr}, Matthew E. and {Fielding}, Drummond B. and {Kim}, Chang-Goo},
+        title = "{Pumping Iron: How Turbulent Metal Diffusion Impacts Multiphase Galactic Outflows}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galactic winds, Galaxy evolution, Hydrodynamical simulations, Stellar feedback, Interstellar medium, 572, 594, 767, 1602, 847, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = sep,
+       volume = {991},
+       number = {1},
+          eid = {16},
+        pages = {16},
+          doi = {10.3847/1538-4357/adf283},
+archivePrefix = {arXiv},
+       eprint = {2407.14599},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...991...16S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250213240S,
+       author = {{Sommovigo}, L. and {Cochrane}, R.~K. and {Somerville}, R.~S. and {Hayward}, C.~C. and {Lovell}, C.~C. and {Starkenburg}, T. and {Popping}, G. and {Iyer}, K. and {Gabrielpillai}, A. and {Ho}, M. and {Steinwandel}, U.~P. and {Perez}, L.~A.},
+        title = "{Learning the Universe: Physically Motivated Priors for Dust Attenuation Curves}",
+      journal = {The Astrophysical Journal},
+     keywords = {Interstellar medium, Interstellar dust, Interstellar dust extinction, Radiative transfer, Galaxy evolution, Hydrodynamical simulations, 847, 836, 837, 1335, 594, 767, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = sep,
+       volume = {990},
+       number = {2},
+          eid = {114},
+        pages = {114},
+          doi = {10.3847/1538-4357/addec1},
+archivePrefix = {arXiv},
+       eprint = {2502.13240},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...990..114S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...990...49G,
+       author = {{Guo}, Minghao and {Kim}, Chang-Goo and {Stone}, James M.},
+        title = "{Evolution of Supernova Remnants in a Cloudy Multiphase Interstellar Medium}",
+      journal = {The Astrophysical Journal},
+     keywords = {Interstellar medium, Supernova remnants, Supernovae, Ejecta, 847, 1667, 1668, 453, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = sep,
+       volume = {990},
+       number = {1},
+          eid = {49},
+        pages = {49},
+          doi = {10.3847/1538-4357/adeb85},
+archivePrefix = {arXiv},
+       eprint = {2411.12809},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...990...49G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250801855F,
+       author = {{Fondi}, Emanuele and {Verde}, Licia and {Baldi}, Marco and {Coulton}, William and {Villaescusa-Navarro}, Francisco and {Wandelt}, Benjamin Dan},
+        title = "{$\texttt{GENGARS}$: Accurate non-Gaussian initial conditions with arbitrary bispectrum for N-body simulations}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, General Relativity and Quantum Cosmology},
+         year = 2025,
+        month = aug,
+          eid = {arXiv:2508.01855},
+        pages = {arXiv:2508.01855},
+          doi = {10.48550/arXiv.2508.01855},
+archivePrefix = {arXiv},
+       eprint = {2508.01855},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250801855F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...989..207B,
+       author = {{Bayer}, Adrian E. and {Villaescusa-Navarro}, Francisco and {Sharief}, Sammy and {Teyssier}, Romain and {Garrison}, Lehman H. and {Perreault-Levasseur}, Laurence and {Bryan}, Greg L. and {Gatti}, Marco and {Visbal}, Eli},
+        title = "{Field-level Comparison and Robustness Analysis of Cosmological N-body Simulations}",
+      journal = {The Astrophysical Journal},
+     keywords = {Cosmology, Large-scale structure of the universe, Astronomy data analysis, N-body simulations, Convolutional neural networks, Sampling distribution, 343, 902, 1858, 1083, 1938, 1899, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = aug,
+       volume = {989},
+       number = {2},
+          eid = {207},
+        pages = {207},
+          doi = {10.3847/1538-4357/adef4e},
+archivePrefix = {arXiv},
+       eprint = {2505.13620},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...989..207B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025A&A...700A..52W,
+       author = {{Weinberger}, R. and {Bhowmick}, A. and {Blecha}, L. and {Bryan}, G. and {Buchner}, J. and {Hernquist}, L. and {Hlavacek-Larrondo}, J. and {Springel}, V.},
+        title = "{Accretion onto supermassive and intermediate-mass black holes in cosmological simulations}",
+      journal = {Astronomy and Astrophysics},
+     keywords = {accretion, accretion disks, methods: numerical, galaxies: formation, quasars: supermassive black holes, Astrophysics of Galaxies, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = aug,
+       volume = {700},
+          eid = {A52},
+        pages = {A52},
+          doi = {10.1051/0004-6361/202554174},
+archivePrefix = {arXiv},
+       eprint = {2502.13241},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025A&A...700A..52W},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250707833S,
+       author = {{Sui}, Ce and {Pandey}, Shivam and {Wandelt}, Benjamin D.},
+        title = "{Fisher Score Matching for Simulation-Based Forecasting and Inference}",
+      journal = {arXiv e-prints},
+     keywords = {Cosmology and Nongalactic Astrophysics, Instrumentation and Methods for Astrophysics},
+         year = 2025,
+        month = jul,
+          eid = {arXiv:2507.07833},
+        pages = {arXiv:2507.07833},
+          doi = {10.48550/arXiv.2507.07833},
+archivePrefix = {arXiv},
+       eprint = {2507.07833},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250707833S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...987..202G,
+       author = {{Guo}, Minghao and {Stone}, James M. and {Quataert}, Eliot and {Springel}, Volker},
+        title = "{Cyclic Zoom: Multiscale GRMHD Modeling of Black Hole Accretion and Feedback}",
+      journal = {The Astrophysical Journal},
+     keywords = {Accretion, Active galactic nuclei, Astrophysical fluid dynamics, Black holes, Bondi accretion, Supermassive black holes, Magnetohydrodynamics, Computational methods, Magnetohydrodynamical simulations, 14, 16, 101, 162, 174, 1663, 1964, 1965, 1966, High Energy Astrophysical Phenomena, Astrophysics of Galaxies},
+         year = 2025,
+        month = jul,
+       volume = {987},
+       number = {2},
+          eid = {202},
+        pages = {202},
+          doi = {10.3847/1538-4357/add1da},
+archivePrefix = {arXiv},
+       eprint = {2504.16802},
+ primaryClass = {astro-ph.HE},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...987..202G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{McAlpine:2024,
+       author = {{McAlpine}, Stuart and {Jasche}, Jens and {Ata}, Metin and {Lavaux}, Guilhem and {Stiskalek}, Richard and {Frenk}, Carlos S. and {Jenkins}, Adrian},
+        title = "{The Manticore Project I: a digital twin of our cosmic neighbourhood from Bayesian field-level analysis}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {galaxies: clusters: general, galaxies: distances and redshifts, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = jun,
+       volume = {540},
+       number = {1},
+        pages = {716-745},
+          doi = {10.1093/mnras/staf767},
+archivePrefix = {arXiv},
+       eprint = {2505.10682},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.540..716M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...986..133L,
+       author = {{Lue}, Amanda and {Genel}, Shy and {Huertas-Company}, Marc and {Villaescusa-Navarro}, Francisco and {Ho}, Matthew},
+        title = "{Cosmology with One Galaxy: Autoencoding the Galaxy Properties Manifold}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galaxy formation, Hydrodynamical simulations, Cosmological models, Cosmological parameters, 595, 767, 337, 339, Cosmology and Nongalactic Astrophysics, Astrophysics of Galaxies},
+         year = 2025,
+        month = jun,
+       volume = {986},
+       number = {2},
+          eid = {133},
+        pages = {133},
+          doi = {10.3847/1538-4357/add724},
+archivePrefix = {arXiv},
+       eprint = {2502.17568},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...986..133L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...985L..46L,
+       author = {{Legin}, Ronan and {Isi}, Maximiliano and {Wong}, Kaze W.~K. and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
+        title = "{Gravitational-wave Parameter Estimation in Non-Gaussian Noise Using Score-based Likelihood Characterization}",
+      journal = {The Astrophysical Journal Letters},
+     keywords = {LIGO, Non-Gaussianity, Bayesian statistics, Gravitational waves, Neural networks, Posterior distribution, Gravitational wave detectors, 920, 1116, 1900, 678, 1933, 1926, 676, Instrumentation and Methods for Astrophysics, High Energy Astrophysical Phenomena, General Relativity and Quantum Cosmology},
+         year = 2025,
+        month = jun,
+       volume = {985},
+       number = {2},
+          eid = {L46},
+        pages = {L46},
+          doi = {10.3847/2041-8213/add681},
+archivePrefix = {arXiv},
+       eprint = {2410.19956},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...985L..46L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv241014623S,
+       author = {{Sui}, Ce and {Bartlett}, Deaglan J. and {Pandey}, Shivam and {Desmond}, Harry and {Ferreira}, Pedro G. and {Wandelt}, Benjamin D.},
+        title = "{SYREN-NEW: Precise formulae for the linear and nonlinear matter power spectra with massive neutrinos and dynamical dark energy}",
+      journal = {Astronomy and Astrophysics},
+     keywords = {methods: numerical, cosmological parameters, cosmology: theory, dark energy, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics, Instrumentation and Methods for Astrophysics, Machine Learning, Neural and Evolutionary Computing},
+         year = 2025,
+        month = jun,
+       volume = {698},
+          eid = {A1},
+        pages = {A1},
+          doi = {10.1051/0004-6361/202452854},
+archivePrefix = {arXiv},
+       eprint = {2410.14623},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025A&A...698A...1S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025PhRvD.111j3521H,
+       author = {{Hadzhiyska}, Boryana and {Ferraro}, Simone},
+        title = "{Refining localtype primordial non-Gaussianity: Sharpened b{\ensuremath{\phi}} constraints through bias expansion}",
+      journal = {Physical Review D},
+     keywords = {Cosmology, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = may,
+       volume = {111},
+       number = {10},
+          eid = {103521},
+        pages = {103521},
+          doi = {10.1103/PhysRevD.111.103521},
+archivePrefix = {arXiv},
+       eprint = {2501.14873},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025PhRvD.111j3521H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025MNRAS.538..518B,
+       author = {{Bhowmick}, Aklant K. and {Blecha}, Laura and {Torrey}, Paul and {Somerville}, Rachel S. and {Kelley}, Luke Zoltan and {Weinberger}, Rainer and {Vogelsberger}, Mark and {Hernquist}, Lars and {Natarajan}, Priyamvada and {Kho}, Jonathan and {Di Matteo}, Tiziana},
+        title = "{Signatures of black hole seeding in the local Universe: predictions from the BRAHMA cosmological simulations}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = mar,
+       volume = {538},
+       number = {1},
+        pages = {518-536},
+          doi = {10.1093/mnras/staf269},
+archivePrefix = {arXiv},
+       eprint = {2411.19332},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.538..518B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025MNRAS.538...11S,
+       author = {{Su}, Kung-Yi and {Bryan}, Greg L. and {Haiman}, Zolt{\'a}n},
+        title = "{Self-regulation of high-redshift black hole accretion via jets: challenges for SMBH formation}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = mar,
+       volume = {538},
+       number = {1},
+        pages = {11-30},
+          doi = {10.1093/mnras/staf228},
+archivePrefix = {arXiv},
+       eprint = {2409.12250},
+ primaryClass = {astro-ph.HE},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.538...11S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240300050K,
+       author = {{Jespersen}, Christian Kragh and {Steinhardt}, Charles L. and {Somerville}, Rachel S. and {Lovell}, Christopher C.},
+        title = "{On the Significance of Rare Objects at High Redshift: The Impact of Cosmic Variance}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galaxies, High-redshift galaxies, Galaxy formation, Astrostatistics, 573, 734, 595, 1882, Astrophysics of Galaxies},
+         year = 2025,
+        month = mar,
+       volume = {982},
+       number = {1},
+          eid = {23},
+        pages = {23},
+          doi = {10.3847/1538-4357/adb422},
+archivePrefix = {arXiv},
+       eprint = {2403.00050},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...982...23J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025ApJ...981..149B,
+       author = {{Borodina}, Olga and {Ni}, Yueying and {Bennett}, Jake S. and {Weinberger}, Rainer and {Bryan}, Greg L. and {Hirschmann}, Michaela and {Farcy}, Marion and {Hlavacek-Larrondo}, Julie and {Hernquist}, Lars},
+        title = "{You Shall Not Pass! The Propagation of Low-/Moderate-powered Jets Through a Turbulent Interstellar Medium}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galaxy jets, Low-luminosity active galactic nuclei, Active galactic nuclei, Hydrodynamical simulations, 601, 2033, 16, 767, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = mar,
+       volume = {981},
+       number = {2},
+          eid = {149},
+        pages = {149},
+          doi = {10.3847/1538-4357/adb016},
+archivePrefix = {arXiv},
+       eprint = {2501.14062},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJ...981..149B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250213242S,
+       author = {{Scoggins}, Matthew T. and {Ho}, Matthew and {Villaescusa-Navarro}, Francisco and {Jamieson}, Drew and {Doeser}, Ludvig and {Bryan}, Greg L.},
+        title = "{Learning the Universe: $3\ h^{-1}{\rm Gpc}$ Tests of a Field Level $N$-body Simulation Emulator}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = feb,
+          eid = {arXiv:2502.13242},
+        pages = {arXiv:2502.13242},
+          doi = {10.48550/arXiv.2502.13242},
+archivePrefix = {arXiv},
+       eprint = {2502.13242},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250213242S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Bartlett:2024,
+       author = {{Bartlett}, Deaglan J. and {Chiarenza}, Marco and {Doeser}, Ludvig and {Leclercq}, Florent},
+        title = "{COmoving Computer Acceleration (COCA): N-body simulations in an emulated frame of reference}",
+      journal = {Astronomy and Astrophysics},
+     keywords = {gravitation, methods: numerical, cosmology: theory, large-scale structure of Universe, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning, Statistics - Machine Learning},
+         year = 2025,
+        month = feb,
+       volume = {694},
+          eid = {A287},
+        pages = {A287},
+          doi = {10.1051/0004-6361/202452217},
+archivePrefix = {arXiv},
+       eprint = {2409.02154},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025A&A...694A.287B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025PhRvD.111b3534H,
+       author = {{Hadzhiyska}, Boryana and {Ferraro}, Simone and {Zhou}, Rongpu},
+        title = "{Tracing cosmic gas in filaments and halos: Low-redshift insights from the kinematic Sunyaev-Zel'dovich effect}",
+      journal = {Physical Review D},
+     keywords = {Cosmology, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+         year = 2025,
+        month = jan,
+       volume = {111},
+       number = {2},
+          eid = {023534},
+        pages = {023534},
+          doi = {10.1103/PhysRevD.111.023534},
+archivePrefix = {arXiv},
+       eprint = {2412.03631},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025PhRvD.111b3534H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2023arXiv230915071M,
+       author = {{Modi}, Chirag and {Pandey}, Shivam and {Ho}, Matthew and {Hahn}, ChangHoon and {R{\'e}galdo-Saint Blancard}, Bruno and {Wandelt}, Benjamin},
+        title = "{Sensitivity analysis of simulation-based inference for galaxy clustering}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2025,
+        month = jan,
+       volume = {536},
+       number = {1},
+        pages = {254-265},
+          doi = {10.1093/mnras/stae2473},
+archivePrefix = {arXiv},
+       eprint = {2309.15071},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.536..254M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{ArkenstoneII,
+       author = {{Smith}, Matthew C. and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Bennett}, Jake S. and {Kim}, Chang-Goo and {Ostriker}, Eve C. and {Somerville}, Rachel S.},
+        title = "{ARKENSTONE - II. A model for unresolved cool clouds entrained in galactic winds in cosmological simulations}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = dec,
+       volume = {535},
+       number = {4},
+        pages = {3550-3576},
+          doi = {10.1093/mnras/stae2589},
+archivePrefix = {arXiv},
+       eprint = {2408.15321},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.535.3550S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Doeser:2023,
+       author = {{Doeser}, Ludvig and {Jamieson}, Drew and {Stopyra}, Stephen and {Lavaux}, Guilhem and {Leclercq}, Florent and {Jasche}, Jens},
+        title = "{Bayesian inference of initial conditions from non-linear cosmic structures using field-level emulators}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
          year = 2024,
-        month = jul,
-          eid = {arXiv:2407.02574},
-        pages = {arXiv:2407.02574},
-          doi = {10.48550/arXiv.2407.02574},
+        month = dec,
+       volume = {535},
+       number = {2},
+        pages = {1258-1277},
+          doi = {10.1093/mnras/stae2429},
 archivePrefix = {arXiv},
-       eprint = {2407.02574},
+       eprint = {2312.09271},
  primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240702574R},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.535.1258D},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2024arXiv240500635B,
+       author = {{Bartlett}, Deaglan J. and {Ho}, Matthew and {Wandelt}, Benjamin D.},
+        title = "{Bye-bye, Local-in-matter-density Bias: The Statistics of the Halo Field Are Poorly Determined by the Local Mass Density}",
+      journal = {The Astrophysical Journal Letters},
+     keywords = {Large-scale structure of the universe, Dark matter distribution, Cosmology, 902, 356, 343, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = dec,
+       volume = {977},
+       number = {2},
+          eid = {L44},
+        pages = {L44},
+          doi = {10.3847/2041-8213/ad97b9},
+archivePrefix = {arXiv},
+       eprint = {2405.00635},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...977L..44B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
-@ARTICLE{Charnock:2020,
-       author = {{Charnock}, Tom and {Lavaux}, Guilhem and {Wandelt}, Benjamin D. and {Sarma Boruah}, Supranta and {Jasche}, Jens and {Hudson}, Michael J.},
-        title = "{Neural physical engines for inferring the halo mass distribution function}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, methods: statistical, galaxies: haloes, dark matter, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2020,
-        month = may,
-       volume = {494},
+@ARTICLE{Hassan2024,
+       author = {{Hassan}, Sultan and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Bryan}, Greg L. and {Burger}, Jan D. and {Fielding}, Drummond B. and {Forbes}, John C. and {Genel}, Shy and {Hernquist}, Lars and {Jeffreson}, Sarah M.~R. and {Motwani}, Bhawna and {Smith}, Matthew C. and {Somerville}, Rachel S. and {Steinwandel}, Ulrich P. and {Teyssier}, Romain},
+        title = "{Toward Implementation of the Pressure-regulated, Feedback-modulated Model of Star Formation in Cosmological Simulations: Methods and Application to TNG}",
+      journal = {The Astrophysical Journal},
+     keywords = {Star formation, Interstellar medium, Stellar feedback, Magnetohydrodynamical simulations, 1569, 847, 1602, 1966, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = nov,
+       volume = {975},
        number = {1},
-        pages = {50-61},
-          doi = {10.1093/mnras/staa682},
+          eid = {151},
+        pages = {151},
+          doi = {10.3847/1538-4357/ad73a4},
 archivePrefix = {arXiv},
-       eprint = {1909.06379},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2020MNRAS.494...50C},
+       eprint = {2409.09121},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...975..151H},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{Jeffreson2024,
+       author = {{Jeffreson}, Sarah M.~R. and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Gensior}, Jindra and {Bryan}, Greg L. and {Davis}, Timothy A. and {Hernquist}, Lars and {Hassan}, Sultan},
+        title = "{Learning the Universe: GalactISM Simulations of Resolved Star Formation and Galactic Outflows across Main-sequence and Quenched Galactic Environments}",
+      journal = {The Astrophysical Journal},
+     keywords = {Disk galaxies, Lenticular galaxies, Spiral galaxies, Interstellar medium, Star formation, Hydrodynamical simulations, Stellar feedback, Galactic and extragalactic astronomy, Galaxy processes, Galaxy properties, Galaxy structure, 391, 915, 1560, 847, 1569, 767, 1602, 563, 614, 615, 622, Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = nov,
+       volume = {975},
+       number = {1},
+          eid = {113},
+        pages = {113},
+          doi = {10.3847/1538-4357/ad793f},
+archivePrefix = {arXiv},
+       eprint = {2409.09114},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...975..113J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
+@ARTICLE{2024arXiv241007548M,
+       author = {{Makinen}, T. Lucas and {Sui}, Ce and {Wandelt}, Benjamin D. and {Porqueres}, Natalia and {Heavens}, Alan},
+        title = "{Hybrid Summary Statistics}",
+      journal = {arXiv e-prints},
+     keywords = {Machine Learning, Cosmology and Nongalactic Astrophysics, Information Theory, Data Analysis, Statistics and Probability},
+         year = 2024,
+        month = oct,
+          eid = {arXiv:2410.07548},
+        pages = {arXiv:2410.07548},
+          doi = {10.48550/arXiv.2410.07548},
+archivePrefix = {arXiv},
+       eprint = {2410.07548},
+ primaryClass = {stat.ML},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv241007548M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240508870G,
+       author = {{Genina}, Anna and {Springel}, Volker and {Rantala}, Antti},
+        title = "{A calibrated model for N-body dynamical friction acting on supermassive black holes}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = oct,
+       volume = {534},
+       number = {1},
+        pages = {957-977},
+          doi = {10.1093/mnras/stae2144},
+archivePrefix = {arXiv},
+       eprint = {2405.08870},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.534..957G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024ApJ...974..193J,
+       author = {{Jo}, Yongseok and {Kim}, Seoyoung and {Kim}, Ji-hoon and {Bryan}, Greg L.},
+        title = "{Evolution of Star Clusters within Galaxies Using Self-consistent Hybrid Hydro/N-body Simulations}",
+      journal = {The Astrophysical Journal},
+     keywords = {Galaxy evolution, Star clusters, N-body simulations, Hydrodynamical simulations, 594, 1567, 1083, 767, Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = oct,
+       volume = {974},
+       number = {2},
+          eid = {193},
+        pages = {193},
+          doi = {10.3847/1538-4357/ad6b16},
+archivePrefix = {arXiv},
+       eprint = {2408.03128},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...974..193J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240511711G,
+       author = {{Guo}, Minghao and {Stone}, James M. and {Quataert}, Eliot and {Kim}, Chang-Goo},
+        title = "{Magnetized Accretion onto and Feedback from Supermassive Black Holes in Elliptical Galaxies}",
+      journal = {The Astrophysical Journal},
+     keywords = {Accretion, Black holes, Supermassive black holes, Active galactic nuclei, Elliptical galaxies, Astrophysical fluid dynamics, Magnetohydrodynamics, Magnetohydrodynamical simulations, 14, 162, 1663, 16, 456, 101, 1964, 1966, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = oct,
+       volume = {973},
+       number = {2},
+          eid = {141},
+        pages = {141},
+          doi = {10.3847/1538-4357/ad5fe7},
+archivePrefix = {arXiv},
+       eprint = {2405.11711},
+ primaryClass = {astro-ph.HE},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...973..141G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{Ding:2024,
        author = {{Ding}, Simon and {Lavaux}, Guilhem and {Jasche}, Jens},
@@ -74,8 +1234,137 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2024arXiv240911401P,
+       author = {{Pandey}, Shivam and {Lanusse}, Francois and {Modi}, Chirag and {Wandelt}, Benjamin D.},
+        title = "{Teaching dark matter simulations to speak the halo language}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2024,
+        month = sep,
+          eid = {arXiv:2409.11401},
+        pages = {arXiv:2409.11401},
+          doi = {10.48550/arXiv.2409.11401},
+archivePrefix = {arXiv},
+       eprint = {2409.11401},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240911401P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
+@ARTICLE{2024arXiv240614658B,
+       author = {{Bhowmick}, Aklant K. and {Blecha}, Laura and {Torrey}, Paul and {Somerville}, Rachel S. and {Kelley}, Luke Zoltan and {Vogelsberger}, Mark and {Weinberger}, Rainer and {Hernquist}, Lars and {Sivasankaran}, Aneesh},
+        title = "{Growth of high-redshift supermassive black holes from heavy seeds in the BRAHMA cosmological simulations: implications of overmassive black holes}",
+      journal = {Monthly Notices of the Royal Astronomical Society},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = sep,
+       volume = {533},
+       number = {2},
+        pages = {1907-1926},
+          doi = {10.1093/mnras/stae1819},
+archivePrefix = {arXiv},
+       eprint = {2406.14658},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.533.1907B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
+@ARTICLE{2024ApJ...973...41Z,
+       author = {{Zhao}, Xiaosheng and {Mao}, Yi and {Zuo}, Shifan and {Wandelt}, Benjamin D.},
+        title = "{Simulation-based Inference of Reionization Parameters from 3D Tomographic 21 cm Light-cone Images. II. Application of Solid Harmonic Wavelet Scattering Transform}",
+      journal = {The Astrophysical Journal},
+     keywords = {Reionization, H I line emission, Astrostatistics, Bayesian statistics, Wavelet analysis, 1383, 690, 1882, 1900, 1918, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = sep,
+       volume = {973},
+       number = {1},
+          eid = {41},
+        pages = {41},
+          doi = {10.3847/1538-4357/ad5ff0},
+archivePrefix = {arXiv},
+       eprint = {2310.17602},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...973...41Z},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Kimetal2024,
+       author = {{Kim}, Chang-Goo and {Ostriker}, Eve C. and {Kim}, Jeong-Gyu and {Gong}, Munan and {Bryan}, Greg L. and {Fielding}, Drummond B. and {Hassan}, Sultan and {Ho}, Matthew and {Jeffreson}, Sarah M.~R. and {Somerville}, Rachel S. and {Steinwandel}, Ulrich P.},
+        title = "{Metallicity Dependence of Pressure-regulated Feedback-modulated Star Formation in the TIGRESS-NCR Simulation Suite}",
+      journal = {The Astrophysical Journal},
+     keywords = {Interstellar medium, Star formation, Magnetohydrodynamical simulations, Stellar feedback, Metallicity, Galaxy formation, Radiative transfer simulations, 847, 1569, 1966, 1602, 1031, 595, 1967, Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = sep,
+       volume = {972},
+       number = {1},
+          eid = {67},
+        pages = {67},
+          doi = {10.3847/1538-4357/ad59ab},
+archivePrefix = {arXiv},
+       eprint = {2405.19227},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...972...67K},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240800839B,
+       author = {{Bourdin}, Antoine and {Legin}, Ronan and {Ho}, Matthew and {Adam}, Alexandre and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
+        title = "{Inpainting Galaxy Counts onto N-Body Simulations over Multiple Cosmologies and Astrophysics}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = aug,
+          eid = {arXiv:2408.00839},
+        pages = {arXiv:2408.00839},
+          doi = {10.48550/arXiv.2408.00839},
+archivePrefix = {arXiv},
+       eprint = {2408.00839},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240800839B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2024eas..conf..352F,
+       author = {{Farcy}, Marion and {Hirschmann}, Michaela and {Choi}, Ena and {Somerville}, Rachel and {Naab}, Thorsten},
+        title = "{Radiatively efficient AGN-driven winds in high redshift, massive galaxies}",
+    booktitle = {EAS2024, European Astronomical Society Annual Meeting},
+         year = 2024,
+        month = jul,
+          eid = {352},
+        pages = {352},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024eas..conf..352F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2024eas..conf...56F,
+       author = {{Farcy}, Marion and {Hirschmann}, Michaela and {Choi}, Ena and {Somerville}, Rachel and {Naab}, Thorsten},
+        title = "{The impact of AGN-driven winds on galaxy and black hole growth in the early Universe}",
+    booktitle = {EAS2024, European Astronomical Society Annual Meeting},
+         year = 2024,
+        month = jul,
+          eid = {56},
+        pages = {56},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024eas..conf...56F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2024arXiv240205137H,
+       author = {{Ho}, Matthew and {Bartlett}, Deaglan J. and {Chartier}, Nicolas and {Cuesta-Lazaro}, Carolina and {Ding}, Simon and {Lapel}, Axel and {Lemos}, Pablo and {Lovell}, Christopher C. and {Makinen}, T. Lucas and {Modi}, Chirag and {Pandya}, Viraj and {Pandey}, Shivam and {Perez}, Lucia A. and {Wandelt}, Benjamin and {Bryan}, Greg L.},
+        title = "{LtU-ILI: An All-in-One Framework for Implicit Inference in Astrophysics and Cosmology}",
+      journal = {The Open Journal of Astrophysics},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Computer Science - Machine Learning},
+         year = 2024,
+        month = jul,
+       volume = {7},
+          eid = {54},
+        pages = {54},
+          doi = {10.33232/001c.120559},
+archivePrefix = {arXiv},
+       eprint = {2402.05137},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024OJAp....7E..54H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{2024MNRAS.532...60K,
        author = {{Koudmani}, Sophie and {Somerville}, Rachel S. and {Sijacki}, Debora and {Bourne}, Martin A. and {Jiang}, Yan-Fei and {Profit}, Kasar},
@@ -95,25 +1384,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2024MNRAS.531.4944W,
-       author = {{Wu}, Yiheng and {Guo}, Hong and {Springel}, Volker},
-        title = "{Improving the accuracy of halo mass based statistics for fast approximate N-body simulations}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = jul,
-       volume = {531},
-       number = {4},
-        pages = {4944-4953},
-          doi = {10.1093/mnras/stae1439},
-archivePrefix = {arXiv},
-       eprint = {2406.10466},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.531.4944W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2024MNRAS.531.4311B,
        author = {{Bhowmick}, Aklant K. and {Blecha}, Laura and {Torrey}, Paul and {Kelley}, Luke Zoltan and {Weinberger}, Rainer and {Vogelsberger}, Mark and {Hernquist}, Lars and {Somerville}, Rachel S. and {Evans}, Analis Eolyn},
         title = "{Introducing the BRAHMA simulation suite: signatures of low-mass black hole seeding models in cosmological simulations}",
@@ -132,236 +1402,24 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-
-
-
-@ARTICLE{2024ApJ...969...28C,
-       author = {{Chaturvedi}, Avinash and {Tonnesen}, Stephanie and {Bryan}, Greg L. and {Popping}, Gerg{\"o} and {Hilker}, Michael and {Serra}, Paolo and {Genel}, Shy},
-        title = "{Observational Predictions for the Survival of Atomic Hydrogen in Simulated Fornax-like Galaxy Clusters}",
+@ARTICLE{2023arXiv230707555T,
+       author = {{Thiele}, Leander and {Massara}, Elena and {Pisani}, Alice and {Hahn}, ChangHoon and {Spergel}, David N. and {Ho}, Shirley and {Wandelt}, Benjamin},
+        title = "{Neutrino Mass Constraint from an Implicit Likelihood Analysis of BOSS Voids}",
       journal = {The Astrophysical Journal},
-     keywords = {Galaxy clusters, Intracluster medium, Intergalactic medium, 584, 858, 813, Astrophysics - Astrophysics of Galaxies},
+     keywords = {Redshift surveys, Voids, Cosmological neutrinos, Neutrino masses, N-body simulations, Neural networks, 1378, 1779, 338, 1102, 1083, 1933, Astrophysics - Cosmology and Nongalactic Astrophysics},
          year = 2024,
         month = jul,
        volume = {969},
-       number = {1},
-          eid = {28},
-        pages = {28},
-          doi = {10.3847/1538-4357/ad43dd},
-archivePrefix = {arXiv},
-       eprint = {2404.16926},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...969...28C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-
-@ARTICLE{2024arXiv240615542S,
-       author = {{Stone}, Connor and {Adam}, Alexandre and {Coogan}, Adam and {Yantovski-Barth}, M.~J. and {Filipp}, Andreas and {Setiawan}, Landung and {Core}, Cordero and {Legin}, Ronan and {Wilson}, Charles and {Missael Barco}, Gabriel and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
-        title = "{Caustics: A Python Package for Accelerated Strong Gravitational Lensing Simulations}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.15542},
-        pages = {arXiv:2406.15542},
-          doi = {10.48550/arXiv.2406.15542},
-archivePrefix = {arXiv},
-       eprint = {2406.15542},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240615542S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240614658B,
-       author = {{Bhowmick}, Aklant K and {Blecha}, Laura and {Torrey}, Paul and {Somerville}, Rachel S and {Kelley}, Luke Zoltan and {Vogelsberger}, Mark and {Weinberger}, Rainer and {Hernquist}, Lars and {Sivasankaran}, Aneesh},
-        title = "{Growth of high redshift supermassive black holes from heavy seeds in the BRAHMA cosmological simulations: Implications of overmassive black holes}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.14658},
-        pages = {arXiv:2406.14658},
-          doi = {10.48550/arXiv.2406.14658},
-archivePrefix = {arXiv},
-       eprint = {2406.14658},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240614658B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024arXiv240608540F,
-       author = {{Ferlito}, Fulvio and {Davies}, Christopher T. and {Springel}, Volker and {Reinecke}, Martin and {Greco}, Alessandro and {Delgado}, Ana Maria and {White}, Simon D.~M. and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Bose}, Sownak and {Hernquist}, Lars},
-        title = "{Ray-tracing vs. Born approximation in full-sky weak lensing simulations of the MillenniumTNG project}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.08540},
-        pages = {arXiv:2406.08540},
-          doi = {10.48550/arXiv.2406.08540},
-archivePrefix = {arXiv},
-       eprint = {2406.08540},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240608540F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240607632V,
-       author = {{Voit}, G.~M. and {Carr}, C. and {Fielding}, D.~B. and {Pandya}, V. and {Bryan}, G.~L. and {Donahue}, M. and {Oppenheimer}, B.~D. and {Somerville}, R.~S.},
-        title = "{Equilibrium States of Galactic Atmospheres II: Interpretation and Implications}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.07632},
-        pages = {arXiv:2406.07632},
-          doi = {10.48550/arXiv.2406.07632},
-archivePrefix = {arXiv},
-       eprint = {2406.07632},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240607632V},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240607631V,
-       author = {{Voit}, G.~M. and {Pandya}, V. and {Fielding}, D.~B. and {Bryan}, G.~L. and {Carr}, C. and {Donahue}, M. and {Oppenheimer}, B.~D. and {Somerville}, R.~S.},
-        title = "{Equilibrium States of Galactic Atmospheres I: The Flip Side of Mass Loading}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.07631},
-        pages = {arXiv:2406.07631},
-          doi = {10.48550/arXiv.2406.07631},
-archivePrefix = {arXiv},
-       eprint = {2406.07631},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240607631V},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv240602664W,
-       author = {{Weller}, Emma Jane and {Pacucci}, Fabio and {Ni}, Yueying and {Hernquist}, Lars and {Park}, Minjung},
-        title = "{Discrepancies Between JWST Observations and Simulations of Quenched Massive Galaxies at $z > 3$: A Comparative Study With IllustrisTNG and ASTRID}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.02664},
-        pages = {arXiv:2406.02664},
-          doi = {10.48550/arXiv.2406.02664},
-archivePrefix = {arXiv},
-       eprint = {2406.02664},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240602664W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Wempe:2024,
-       author = {{Wempe}, Ewoud and {Lavaux}, Guilhem and {White}, Simon D.~M. and {Helmi}, Amina and {Jasche}, Jens and {Stopyra}, Stephen},
-        title = "{Constrained cosmological simulations of the Local Group using Bayesian hierarchical field-level inference}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jun,
-          eid = {arXiv:2406.02228},
-        pages = {arXiv:2406.02228},
-          doi = {10.48550/arXiv.2406.02228},
-archivePrefix = {arXiv},
-       eprint = {2406.02228},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240602228W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024PhRvD.109l3531C,
-       author = {{Cuesta-Lazaro}, Carolina and {Mishra-Sharma}, Siddharth},
-        title = "{Point cloud approach to generative modeling for galaxy surveys at the field level}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning, Statistics - Machine Learning},
-         year = 2024,
-        month = jun,
-       volume = {109},
-       number = {12},
-          eid = {123531},
-        pages = {123531},
-          doi = {10.1103/PhysRevD.109.123531},
-archivePrefix = {arXiv},
-       eprint = {2311.17141},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109l3531C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024MNRAS.531.2213S,
-       author = {{Stopyra}, Stephen and {Peiris}, Hiranya V. and {Pontzen}, Andrew and {Jasche}, Jens and {Lavaux}, Guilhem},
-        title = "{An antihalo void catalogue of the Local Super-Volume}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-       volume = {531},
        number = {2},
-        pages = {2213-2222},
-          doi = {10.1093/mnras/stae1251},
+          eid = {89},
+        pages = {89},
+          doi = {10.3847/1538-4357/ad434e},
 archivePrefix = {arXiv},
-       eprint = {2311.12926},
+       eprint = {2307.07555},
  primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.531.2213S},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...969...89T},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-@ARTICLE{2024MNRAS.531..930C,
-       author = {{Costa}, Tiago},
-        title = "{The host dark matter haloes of the first quasars}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jun,
-       volume = {531},
-       number = {1},
-        pages = {930-944},
-          doi = {10.1093/mnras/stae1157},
-archivePrefix = {arXiv},
-       eprint = {2308.12987},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.531..930C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024MNRAS.530.4868Y,
-       author = {{Yung}, L.~Y. Aaron and {Somerville}, Rachel S. and {Nguyen}, Tri and {Behroozi}, Peter and {Modi}, Chirag and {Gardner}, Jonathan P.},
-        title = "{Characterizing ultra-high-redshift dark matter halo demographics and assembly histories with the GUREFT simulations}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-       volume = {530},
-       number = {4},
-        pages = {4868-4886},
-          doi = {10.1093/mnras/stae1188},
-archivePrefix = {arXiv},
-       eprint = {2309.14408},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.530.4868Y},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
 
 @ARTICLE{2024ApJ...968...11L,
        author = {{Lee}, Max E. and {Genel}, Shy and {Wandelt}, Benjamin D. and {Zhang}, Benjamin and {Delgado}, Ana Maria and {Pandey}, Shivam and {Lau}, Erwin T. and {Carr}, Christopher and {Cook}, Harrison and {Nagai}, Daisuke and {Angles-Alcazar}, Daniel and {Villaescusa-Navarro}, Francisco and {Bryan}, Greg L.},
@@ -379,314 +1437,6 @@ archivePrefix = {arXiv},
        eprint = {2403.10609},
  primaryClass = {astro-ph.GA},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...968...11L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...967L..28M,
-       author = {{Menon}, Shyam H. and {Lancaster}, Lachlan and {Burkhart}, Blakesley and {Somerville}, Rachel S. and {Dekel}, Avishai and {Krumholz}, Mark R.},
-        title = "{The Interplay between the Initial Mass Function and Star Formation Efficiency through Radiative Feedback at High Stellar Surface Densities}",
-      journal = {The Astrophysical Journall},
-     keywords = {Stellar feedback, Radiative transfer simulations, Star formation, Gas-to-dust ratio, Young star clusters, Initial mass function, Starburst galaxies, 1602, 1967, 1569, 638, 1833, 796, 1570, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-       volume = {967},
-       number = {2},
-          eid = {L28},
-        pages = {L28},
-          doi = {10.3847/2041-8213/ad462d},
-archivePrefix = {arXiv},
-       eprint = {2405.00813},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...967L..28M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...967..152A,
-       author = {{Alfonzo}, Juan Pablo and {Iyer}, Kartheik G. and {Akiyama}, Masayuki and {Bryan}, Greg L. and {Cooray}, Suchetha and {Ludwig}, Eric and {Mowla}, Lamiya and {Omori}, Kiyoaki C. and {Pacifici}, Camilla and {Speagle}, Joshua S. and {Wu}, John F.},
-        title = "{Katachi (形): Decoding the Imprints of Past Star Formation on Present-day Morphology in Galaxies with Interpretable CNNs}",
-      journal = {The Astrophysical Journal},
-     keywords = {Extragalactic astronomy, Galaxy classification systems, Galaxy evolution, Astronomy data analysis, Convolutional neural networks, 506, 582, 594, 1858, 1938, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jun,
-       volume = {967},
-       number = {2},
-          eid = {152},
-        pages = {152},
-          doi = {10.3847/1538-4357/ad3b95},
-archivePrefix = {arXiv},
-       eprint = {2404.05146},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...967..152A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024ApJ...967..125S,
-       author = {{Steinwandel}, Ulrich P. and {Dolag}, Klaus and {B{\"o}ss}, Ludwig M. and {Marin-Gilabert}, Tirso},
-        title = "{Toward Cosmological Simulations of the Magnetized Intracluster Medium with Resolved Coulomb Collision Scale}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy clusters, Magnetohydrodynamical simulations, Intracluster medium, Magnetic fields, Extragalactic magnetic fields, Cosmic magnetic fields theory, 584, 1966, 858, 994, 507, 321, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jun,
-       volume = {967},
-       number = {2},
-          eid = {125},
-        pages = {125},
-          doi = {10.3847/1538-4357/ad39ee},
-archivePrefix = {arXiv},
-       eprint = {2306.04692},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...967..125S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024A&A...686A.209B,
-       author = {{Bartlett}, Deaglan J. and {Kammerer}, Lukas and {Kronberger}, Gabriel and {Desmond}, Harry and {Ferreira}, Pedro G. and {Wandelt}, Benjamin D. and {Burlacu}, Bogdan and {Alonso}, David and {Zennaro}, Matteo},
-        title = "{A precise symbolic emulator of the linear matter power spectrum}",
-      journal = {Astronomy and Astrophysics},
-     keywords = {methods: numerical, cosmological parameters, cosmology: theory, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning, Computer Science - Neural and Evolutionary Computing},
-         year = 2024,
-        month = jun,
-       volume = {686},
-          eid = {A209},
-        pages = {A209},
-          doi = {10.1051/0004-6361/202348811},
-archivePrefix = {arXiv},
-       eprint = {2311.15865},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024A&A...686A.209B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024A&A...686A.150B,
-       author = {{Bartlett}, Deaglan J. and {Wandelt}, Benjamin D. and {Zennaro}, Matteo and {Ferreira}, Pedro G. and {Desmond}, Harry},
-        title = "{SYREN-HALOFIT: A fast, interpretable, high-precision formula for the {\ensuremath{\Lambda}}CDM nonlinear matter power spectrum}",
-      journal = {Astronomy and Astrophysics},
-     keywords = {methods: numerical, cosmological parameters, cosmology: theory, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning, Computer Science - Neural and Evolutionary Computing},
-         year = 2024,
-        month = jun,
-       volume = {686},
-          eid = {A150},
-        pages = {A150},
-          doi = {10.1051/0004-6361/202449854},
-archivePrefix = {arXiv},
-       eprint = {2402.17492},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024A&A...686A.150B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{Kimetal2024,
-       author = {{Kim}, Chang-Goo and {Ostriker}, Eve C. and {Kim}, Jeong-Gyu and {Gong}, Munan and {Bryan}, Greg L. and {Fielding}, Drummond B. and {Hassan}, Sultan and {Ho}, Matthew and {Jeffreson}, Sarah M.~R. and {Somerville}, Rachel S. and {Steinwandel}, Ulrich P.},
-        title = "{Metallicity Dependence of Pressure-regulated Feedback-modulated Star Formation in the TIGRESS-NCR Simulation Suite}",
-      journal = {\apj},
-     keywords = {Interstellar medium, Star formation, Magnetohydrodynamical simulations, Stellar feedback, Metallicity, Galaxy formation, Radiative transfer simulations, 847, 1569, 1966, 1602, 1031, 595, 1967, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = sep,
-       volume = {972},
-       number = {1},
-          eid = {67},
-        pages = {67},
-          doi = {10.3847/1538-4357/ad59ab},
-archivePrefix = {arXiv},
-       eprint = {2405.19227},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...972...67K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-
-
-
-@ARTICLE{2024arXiv240513119C,
-       author = {{Chatterjee}, Atrideb and {Villaescusa-Navarro}, Francisco},
-        title = "{Cosmology from point clouds}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.13119},
-        pages = {arXiv:2405.13119},
-          doi = {10.48550/arXiv.2405.13119},
-archivePrefix = {arXiv},
-       eprint = {2405.13119},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240513119C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240513110H,
-       author = {{Holguin}, Francisco and {Hayward}, Christopher C. and {Ma}, Xiangcheng and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Cochrane}, Rachel K.},
-        title = "{Host-galaxy stars can dominate the ionizing radiation field of the circumgalactic medium in galaxies at Cosmic Noon}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.13110},
-        pages = {arXiv:2405.13110},
-          doi = {10.48550/arXiv.2405.13110},
-archivePrefix = {arXiv},
-       eprint = {2405.13110},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240513110H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024arXiv240511711G,
-       author = {{Guo}, Minghao and {Stone}, James M. and {Quataert}, Eliot and {Kim}, Chang-Goo},
-        title = "{Magnetized Accretion onto and Feedback from Supermassive Black Holes in Elliptical Galaxies}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.11711},
-        pages = {arXiv:2405.11711},
-          doi = {10.48550/arXiv.2405.11711},
-archivePrefix = {arXiv},
-       eprint = {2405.11711},
- primaryClass = {astro-ph.HE},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240511711G},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
-}
-
-@ARTICLE{2024arXiv240508870G,
-       author = {{Genina}, Anna and {Springel}, Volker and {Rantala}, Antti},
-        title = "{A calibrated model for N-body dynamical friction acting on supermassive black holes}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.08870},
-        pages = {arXiv:2405.08870},
-          doi = {10.48550/arXiv.2405.08870},
-archivePrefix = {arXiv},
-       eprint = {2405.08870},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240508870G},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
-}
-
-@ARTICLE{2024arXiv240508869D,
-       author = {{Deng}, Yunwei and {Li}, Hui and {Liu}, Boyuan and {Kannan}, Rahul and {Smith}, Aaron and {Bryan}, Greg L.},
-        title = "{RIGEL: Simulating dwarf galaxies at solar mass resolution with radiative transfer and feedback from individual massive stars}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.08869},
-        pages = {arXiv:2405.08869},
-          doi = {10.48550/arXiv.2405.08869},
-archivePrefix = {arXiv},
-       eprint = {2405.08869},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240508869D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240508261L,
-       author = {{Lemos}, Pablo and {Agarwal}, Jessica and {Marschall}, Raphael and {Pfeifer}, Marius},
-        title = "{Ejection and Dynamics of Aggregates in the Coma of Comet 67P/Churyumov-Gerasimenko}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Earth and Planetary Astrophysics},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.08261},
-        pages = {arXiv:2405.08261},
-          doi = {10.48550/arXiv.2405.08261},
-archivePrefix = {arXiv},
-       eprint = {2405.08261},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240508261L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024arXiv240505598F,
-       author = {{Fl{\"o}ss}, Thomas and {Coulton}, William R. and {Duivenvoorden}, Adriaan J. and {Villaescusa-Navarro}, Francisco and {Wandelt}, Benjamin D.},
-        title = "{Denoising Diffusion Delensing Delight: Reconstructing the Non-Gaussian CMB Lensing Potential with Diffusion Models}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.05598},
-        pages = {arXiv:2405.05598},
-          doi = {10.48550/arXiv.2405.05598},
-archivePrefix = {arXiv},
-       eprint = {2405.05598},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240505598F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240505255M,
-       author = {{Mudur}, Nayantara and {Cuesta-Lazaro}, Carolina and {Finkbeiner}, Douglas P.},
-        title = "{Diffusion-HMC: Parameter Inference with Diffusion Model driven Hamiltonian Monte Carlo}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.05255},
-        pages = {arXiv:2405.05255},
-          doi = {10.48550/arXiv.2405.05255},
-archivePrefix = {arXiv},
-       eprint = {2405.05255},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240505255M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024arXiv240502396L,
-       author = {{Lancaster}, Lachlan and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Kim}, Jeong-Gyu and {Bryan}, Greg L.},
-        title = "{Geometry, Dissipation, Cooling, and the Dynamical Evolution of Wind-Blown Bubbles}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.02396},
-        pages = {arXiv:2405.02396},
-          doi = {10.48550/arXiv.2405.02396},
-archivePrefix = {arXiv},
-       eprint = {2405.02396},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240502396L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024arXiv240500635B,
-       author = {{Bartlett}, Deaglan J. and {Ho}, Matthew and {Wandelt}, Benjamin D.},
-        title = "{Bye bye, local bias: the statistics of the halo field are poorly determined by the local mass density}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = may,
-          eid = {arXiv:2405.00635},
-        pages = {arXiv:2405.00635},
-          doi = {10.48550/arXiv.2405.00635},
-archivePrefix = {arXiv},
-       eprint = {2405.00635},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240500635B},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -709,30 +1459,11 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2024PhRvD.109j3533R,
-       author = {{Ried Guachalla}, Bernardita and {Schaan}, Emmanuel and {Hadzhiyska}, Boryana and {Ferraro}, Simone},
-        title = "{Velocity reconstruction in the era of DESI and Rubin/LSST. I. Exploring spectroscopic, photometric, and hybrid samples}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-       volume = {109},
-       number = {10},
-          eid = {103533},
-        pages = {103533},
-          doi = {10.1103/PhysRevD.109.103533},
-archivePrefix = {arXiv},
-       eprint = {2312.12435},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109j3533R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2024PhRvD.109j3530H,
        author = {{Hadzhiyska}, Boryana and {Garrison}, Lehman H. and {Eisenstein}, Daniel J. and {Ferraro}, Simone},
         title = "{Modest set of simulations of local-type primordial non-Gaussianity in the DESI era}",
       journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     keywords = {Cosmology and Nongalactic Astrophysics},
          year = 2024,
         month = may,
        volume = {109},
@@ -747,74 +1478,10 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-
-@ARTICLE{2024PhRvD.109j3517P,
-       author = {{Paopiamsap}, Anya and {Alonso}, David and {Bartlett}, Deaglan J. and {Bilicki}, Maciej},
-        title = "{Constraints on dark matter and astrophysics from tomographic {\ensuremath{\gamma}} -ray cross-correlations}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2024,
-        month = may,
-       volume = {109},
-       number = {10},
-          eid = {103517},
-        pages = {103517},
-          doi = {10.1103/PhysRevD.109.103517},
-archivePrefix = {arXiv},
-       eprint = {2307.14881},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109j3517P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-
-@ARTICLE{2024MNRAS.530.1711S,
-       author = {{Stern}, Jonathan and {Fielding}, Drummond and {Hafen}, Zachary and {Su}, Kung-Yi and {Naor}, Nadav and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e} and {Quataert}, Eliot and {Bullock}, James},
-        title = "{Accretion onto disc galaxies via hot and rotating CGM inflows}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: disc, galaxies: evolution, galaxies: formation, galaxies: haloes, intergalactic medium, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-       volume = {530},
-       number = {2},
-        pages = {1711-1731},
-          doi = {10.1093/mnras/stae824},
-archivePrefix = {arXiv},
-       eprint = {2306.00092},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.530.1711S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024MNRAS.530...52D,
-       author = {{DeFelippis}, Daniel and {Bournaud}, Fr{\'e}d{\'e}ric and {Bouch{\'e}}, Nicolas and {Tollet}, Edouard and {Farcy}, Marion and {Rey}, Maxime and {Rosdahl}, Joakim and {Blaizot}, J{\'e}r{\'e}my},
-        title = "{The effect of cosmic rays on the observational properties of the CGM}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, cosmic rays, galaxies: evolution, galaxies: haloes, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-       volume = {530},
-       number = {1},
-        pages = {52-65},
-          doi = {10.1093/mnras/stae837},
-archivePrefix = {arXiv},
-       eprint = {2403.14748},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.530...52D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
 @ARTICLE{2024ApJ...966L..18H,
        author = {{Hahn}, ChangHoon and {Villaescusa-Navarro}, Francisco and {Melchior}, Peter and {Teyssier}, Romain},
         title = "{Cosmology with Galaxy Photometry Alone}",
-      journal = {The Astrophysical Journall},
+      journal = {The Astrophysical Journal Letters},
      keywords = {Cosmological parameters, Astrostatistics, Neural networks, Galaxy formation, Magnetohydrodynamical simulations, 339, 1882, 1933, 595, 1966},
          year = 2024,
         month = may,
@@ -824,184 +1491,6 @@ archivePrefix = {arXiv},
         pages = {L18},
           doi = {10.3847/2041-8213/ad3f1e},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...966L..18H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...966..181A,
-       author = {{Abruzzo}, Matthew W. and {Fielding}, Drummond B. and {Bryan}, Greg L.},
-        title = "{Taming the TuRMoiL: The Temperature Dependence of Turbulence in Cloud{\textendash}Wind Interactions}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy evolution, Hydrodynamical simulations, Interstellar clouds, Circumgalactic medium, Galactic winds, 594, 767, 834, 1879, 572, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = may,
-       volume = {966},
-       number = {2},
-          eid = {181},
-        pages = {181},
-          doi = {10.3847/1538-4357/ad1e51},
-archivePrefix = {arXiv},
-       eprint = {2210.15679},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...966..181A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2024ASPC..535..123N,
-       author = {{Ntampaka}, M. and {Ho}, M. and {Nord}, B.},
-        title = "{Building Trustworthy Machine Learning Models for Astronomy}",
-    booktitle = {Astronomical Society of the Pacific Conference Series},
-         year = 2024,
-       editor = {{Hugo}, B.~V. and {Van Rooyen}, R. and {Smirnov}, O.~M.},
-       series = {Astronomical Society of the Pacific Conference Series},
-       volume = {535},
-        month = may,
-        pages = {123},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ASPC..535..123N},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024arXiv240415396D,
-       author = {{Diesing}, Rebecca and {Guo}, Minghao and {Kim}, Chang-Goo and {Stone}, James and {Caprioli}, Damiano},
-        title = "{Nonthermal Signatures of Radiative Supernova Remnants}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2024,
-        month = apr,
-          eid = {arXiv:2404.15396},
-        pages = {arXiv:2404.15396},
-          doi = {10.48550/arXiv.2404.15396},
-archivePrefix = {arXiv},
-       eprint = {2404.15396},
- primaryClass = {astro-ph.HE},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240415396D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240413837Z,
-       author = {{Zhu}, Bocheng and {Springel}, Volker},
-        title = "{The effect of local photoionization on the galaxy properties and the circumgalactic medium in simulations of Milky Way-sized galaxies}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = apr,
-          eid = {arXiv:2404.13837},
-        pages = {arXiv:2404.13837},
-          doi = {10.48550/arXiv.2404.13837},
-archivePrefix = {arXiv},
-       eprint = {2404.13837},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240413837Z},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024arXiv240404228M,
-       author = {{Massara}, Elena and {Hahn}, ChangHoon and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Lemos}, Pablo and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {Parker}, Liam and {R{\'e}galdo-Saint Blancard}, Bruno},
-        title = "{\{\textbackslashsc SimBIG\}: Cosmological Constraints using Simulation-Based Inference of Galaxy Clustering with Marked Power Spectra}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = apr,
-          eid = {arXiv:2404.04228},
-        pages = {arXiv:2404.04228},
-          doi = {10.48550/arXiv.2404.04228},
-archivePrefix = {arXiv},
-       eprint = {2404.04228},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240404228M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240401175R,
-       author = {{Rhea}, Carter Lee and {Hlavacek-Larrondo}, Julie and {Giroux}, Justine and {Thilloy}, Auriane and {Choi}, Hyunseop and {Rousseau-Nepton}, Laurie and {Gendron-Marsolais}, Marie-Lou and {Pasquato}, Mario and {Prunet}, Simon},
-        title = "{Reconstructing Robust Background IFU spectra using Machine Learning}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = apr,
-          eid = {arXiv:2404.01175},
-        pages = {arXiv:2404.01175},
-          doi = {10.48550/arXiv.2404.01175},
-archivePrefix = {arXiv},
-       eprint = {2404.01175},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240401175R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024PhRvD.109h3536L,
-       author = {{Lemos}, Pablo and {Parker}, Liam and {Hahn}, ChangHoon and {Ho}, Shirley and {Eickenberg}, Michael and {Hou}, Jiamin and {Massara}, Elena and {Modi}, Chirag and {Dizgah}, Azadeh Moradinezhad and {Blancard}, Bruno R{\'e}galdo-Saint and {Spergel}, David and {SimBIG Collaboration}},
-        title = "{Field-level simulation-based inference of galaxy clustering with convolutional neural networks}",
-      journal = {Physical Review D},
-         year = 2024,
-        month = apr,
-       volume = {109},
-       number = {8},
-          eid = {083536},
-        pages = {083536},
-          doi = {10.1103/PhysRevD.109.083536},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109h3536L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024PhRvD.109h3535R,
-       author = {{R{\'e}galdo-Saint Blancard}, Bruno and {Hahn}, ChangHoon and {Ho}, Shirley and {Hou}, Jiamin and {Lemos}, Pablo and {Massara}, Elena and {Modi}, Chirag and {Dizgah}, Azadeh Moradinezhad and {Parker}, Liam and {Yao}, Yuling and {Eickenberg}, Michael and {SimBIG Collaboration}},
-        title = "{Galaxy clustering analysis with SimBIG and the wavelet scattering transform}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = apr,
-       volume = {109},
-       number = {8},
-          eid = {083535},
-        pages = {083535},
-          doi = {10.1103/PhysRevD.109.083535},
-archivePrefix = {arXiv},
-       eprint = {2310.15250},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109h3535R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024PhRvD.109h3534H,
-       author = {{Hahn}, ChangHoon and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Lemos}, Pablo and {Massara}, Elena and {Modi}, Chirag and {Dizgah}, Azadeh Moradinezhad and {Parker}, Liam and {Blancard}, Bruno R{\'e}galdo-Saint and {SimBIG Collaboration}},
-        title = "{Cosmological constraints from the nonlinear galaxy bispectrum}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = apr,
-       volume = {109},
-       number = {8},
-          eid = {083534},
-        pages = {083534},
-          doi = {10.1103/PhysRevD.109.083534},
-archivePrefix = {arXiv},
-       eprint = {2310.15243},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109h3534H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024MNRAS.529.4896G,
-       author = {{Gebhardt}, Matthew and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Borrow}, Josh and {Genel}, Shy and {Villaescusa-Navarro}, Francisco and {Ni}, Yueying and {Lovell}, Christopher C. and {Nagai}, Daisuke and {Dav{\'e}}, Romeel and {Marinacci}, Federico and {Vogelsberger}, Mark and {Hernquist}, Lars},
-        title = "{Cosmological baryon spread and impact on matter clustering in CAMELS}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: evolution, galaxies: formation, cosmology: large-scale structure of Universe, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = apr,
-       volume = {529},
-       number = {4},
-        pages = {4896-4913},
-          doi = {10.1093/mnras/stae817},
-archivePrefix = {arXiv},
-       eprint = {2307.11832},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.529.4896G},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -1023,195 +1512,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-
-
-@ARTICLE{2024MNRAS.529.1405L,
-       author = {{Liu}, Yikai and {Wang}, Peng and {Guo}, Hong and {Springel}, Volker and {Bose}, Sownak and {Pakmor}, R{\"u}diger and {Hernquist}, Lars},
-        title = "{The origin of lopsided satellite galaxy distribution around isolated systems in MillenniumTNG}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: formation, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = apr,
-       volume = {529},
-       number = {2},
-        pages = {1405-1413},
-          doi = {10.1093/mnras/stae625},
-archivePrefix = {arXiv},
-       eprint = {2403.01217},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.529.1405L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024ApJ...965..156J,
-       author = {{Jung}, Minyong and {Kim}, Ji-hoon and {Oh}, Boon Kiat and {Hong}, Sungwook E. and {Lee}, Jaehyun and {Kim}, Juhan},
-        title = "{Merger-tree-based Galaxy Matching: A Comparative Study across Different Resolutions}",
-      journal = {The Astrophysical Journal},
-     keywords = {Astronomical simulations, Hydrodynamical simulations, Galaxy formation, 1857, 767, 595, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = apr,
-       volume = {965},
-       number = {2},
-          eid = {156},
-        pages = {156},
-          doi = {10.3847/1538-4357/ad34d1},
-archivePrefix = {arXiv},
-       eprint = {2312.02466},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...965..156J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...965..101C,
-       author = {{Chuang}, Chen-Yu and {Jespersen}, Christian Kragh and {Lin}, Yen-Ting and {Ho}, Shirley and {Genel}, Shy},
-        title = "{Leaving No Branches Behind: Predicting Baryonic Properties of Galaxies from Merger Trees}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy formation, Galaxy physics, Galaxy dark matter halos, Astrostatistics, Neural networks, 595, 612, 1880, 1882, 1933, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = apr,
-       volume = {965},
-       number = {2},
-          eid = {101},
-        pages = {101},
-          doi = {10.3847/1538-4357/ad2b6c},
-archivePrefix = {arXiv},
-       eprint = {2311.09162},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...965..101C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2024arXiv240400129Z,
-       author = {{Zhu}, Jingyao and {Tonnesen}, Stephanie and {Bryan}, Greg L. and {Putman}, Mary E.},
-        title = "{It's a Breeze: The Circumgalactic Medium of a Dwarf Galaxy is Easy to Strip}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2404.00129},
-        pages = {arXiv:2404.00129},
-          doi = {10.48550/arXiv.2404.00129},
-archivePrefix = {arXiv},
-       eprint = {2404.00129},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240400129Z},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv240310648O,
-       author = {{Ono}, Victoria and {Park}, Core Francisco and {Mudur}, Nayantara and {Ni}, Yueying and {Cuesta-Lazaro}, Carolina and {Villaescusa-Navarro}, Francisco},
-        title = "{Debiasing with Diffusion: Probabilistic reconstruction of Dark Matter fields from galaxies with CAMELS}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2403.10648},
-        pages = {arXiv:2403.10648},
-          doi = {10.48550/arXiv.2403.10648},
-archivePrefix = {arXiv},
-       eprint = {2403.10648},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240310648O},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240309476O,
-       author = {{Oren}, Yossi and {Sternberg}, Amiel and {McKee}, Christopher F. and {Faerman}, Yakov and {Genel}, Shy},
-        title = "{Sunyaev-Zeldovich Signals from $L^*$ Galaxies: Observations, Analytics, and Simulations}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2403.09476},
-        pages = {arXiv:2403.09476},
-          doi = {10.48550/arXiv.2403.09476},
-archivePrefix = {arXiv},
-       eprint = {2403.09476},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240309476O},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240308871S,
-       author = {{Siwek}, Magdalena and {Kelley}, Luke Zoltan and {Hernquist}, Lars},
-        title = "{Signatures of Circumbinary Disk Dynamics in Multi-Messenger Population Studies of Massive Black Hole Binaries}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2403.08871},
-        pages = {arXiv:2403.08871},
-          doi = {10.48550/arXiv.2403.08871},
-archivePrefix = {arXiv},
-       eprint = {2403.08871},
- primaryClass = {astro-ph.HE},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240308871S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024arXiv240302414R,
-       author = {{Ravi}, Jyotsna and {Hadzhiyska}, Boryana and {White}, Martin and {Hernquist}, Lars and {Bose}, Sownak},
-        title = "{Examining Lyman-alpha Emitters through MillenniumTNG in anticipation of DESI-II}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2403.02414},
-        pages = {arXiv:2403.02414},
-          doi = {10.48550/arXiv.2403.02414},
-archivePrefix = {arXiv},
-       eprint = {2403.02414},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240302414R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240300490J,
-       author = {{Jung}, Gabriel and {Ravenni}, Andrea and {Liguori}, Michele and {Baldi}, Marco and {Coulton}, William R. and {Villaescusa-Navarro}, Francisco and {Wandelt}, Benjamin D.},
-        title = "{Quijote-PNG: Optimizing the summary statistics to measure Primordial non-Gaussianity}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = mar,
-          eid = {arXiv:2403.00490},
-        pages = {arXiv:2403.00490},
-          doi = {10.48550/arXiv.2403.00490},
-archivePrefix = {arXiv},
-       eprint = {2403.00490},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240300490J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024PhRvD.109f3513C,
-       author = {{Chen}, Ziyang and {Jamieson}, Drew and {Komatsu}, Eiichiro and {Bose}, Sownak and {Dolag}, Klaus and {Hadzhiyska}, Boryana and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Hernquist}, Lars and {Kannan}, Rahul and {Pakmor}, R{\"u}diger and {Springel}, Volker},
-        title = "{Statistics of thermal gas pressure as a probe of cosmology and galaxy formation}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = mar,
-       volume = {109},
-       number = {6},
-          eid = {063513},
-        pages = {063513},
-          doi = {10.1103/PhysRevD.109.063513},
-archivePrefix = {arXiv},
-       eprint = {2309.16323},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024PhRvD.109f3513C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2024MLS&T...5a5008J,
        author = {{Jeffrey}, Niall and {Wandelt}, Benjamin D.},
         title = "{Evidence Networks: simple losses for fast, amortized, neural Bayesian model comparison}",
@@ -1228,26 +1528,6 @@ archivePrefix = {arXiv},
        eprint = {2305.11241},
  primaryClass = {cs.LG},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024MLS&T...5a5008J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024ApJ...964...99A,
-       author = {{Armillotta}, Lucia and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Jiang}, Yan-Fei},
-        title = "{Cosmic-Ray Acceleration of Galactic Outflows in Multiphase Gas}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmic rays, Interstellar medium, Magnetohydrodynamical simulations, 329, 847, 1966, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2024,
-        month = mar,
-       volume = {964},
-       number = {1},
-          eid = {99},
-        pages = {99},
-          doi = {10.3847/1538-4357/ad1e5c},
-archivePrefix = {arXiv},
-       eprint = {2401.04169},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...964...99A},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -1270,234 +1550,17 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2024ApJ...963...54P,
-       author = {{Pandya}, Viraj and {Zhang}, Haowen and {Huertas-Company}, Marc and {Iyer}, Kartheik G. and {McGrath}, Elizabeth and {Barro}, Guillermo and {Finkelstein}, Steven L. and {K{\"u}mmel}, Martin and {Hartley}, William G. and {Ferguson}, Henry C. and {Kartaltepe}, Jeyhan S. and {Primack}, Joel and {Dekel}, Avishai and {Faber}, Sandra M. and {Koo}, David C. and {Bryan}, Greg L. and {Somerville}, Rachel S. and {Amor{\'\i}n}, Ricardo O. and {Arrabal Haro}, Pablo and {Bagley}, Micaela B. and {Bell}, Eric F. and {Bertin}, Emmanuel and {Costantin}, Luca and {Dav{\'e}}, Romeel and {Dickinson}, Mark and {Feldmann}, Robert and {Fontana}, Adriano and {Gavazzi}, Raphael and {Giavalisco}, Mauro and {Grazian}, Andrea and {Grogin}, Norman A. and {Guo}, Yuchen and {Hahn}, ChangHoon and {Holwerda}, Benne W. and {Kewley}, Lisa J. and {Kirkpatrick}, Allison and {Kocevski}, Dale D. and {Koekemoer}, Anton M. and {Lotz}, Jennifer M. and {Lucas}, Ray A. and {Papovich}, Casey and {Pentericci}, Laura and {P{\'e}rez-Gonz{\'a}lez}, Pablo G. and {Pirzkal}, Nor and {Ravindranath}, Swara and {Rose}, Caitlin and {Schefer}, Marc and {Simons}, Raymond C. and {Straughn}, Amber N. and {Tacchella}, Sandro and {Trump}, Jonathan R. and {de la Vega}, Alexander and {Wilkins}, Stephen M. and {Wuyts}, Stijn and {Yang}, Guang and {Yung}, L.~Y. Aaron},
-        title = "{Galaxies Going Bananas: Inferring the 3D Geometry of High-redshift Galaxies with JWST-CEERS}",
-      journal = {The Astrophysical Journal},
-     keywords = {High-redshift galaxies, Galaxy classification systems, Dwarf galaxies, Galaxy structure, James Webb Space Telescope, Galaxy disks, Galaxy spheroids, Galaxy radii, Galaxy masses, 734, 582, 416, 622, 2291, 589, 2032, 617, 607, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = mar,
-       volume = {963},
-       number = {1},
-          eid = {54},
-        pages = {54},
-          doi = {10.3847/1538-4357/ad1a13},
-archivePrefix = {arXiv},
-       eprint = {2310.15232},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...963...54P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-
-@ARTICLE{2024arXiv240300050K,
-       author = {{Kragh Jespersen}, Christian and {Steinhardt}, Charles L. and {Somerville}, Rachel S. and {Lovell}, Christopher C.},
-        title = "{On the Significance of Rare Objects at High Redshift: The Impact of Cosmic Variance}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = feb,
-          eid = {arXiv:2403.00050},
-        pages = {arXiv:2403.00050},
-          doi = {10.48550/arXiv.2403.00050},
-archivePrefix = {arXiv},
-       eprint = {2403.00050},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240300050K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-
-@ARTICLE{2024arXiv240208408W,
-       author = {{Wright}, Ruby J. and {Somerville}, Rachel S. and {Lagos}, Claudia del P. and {Schaller}, Matthieu and {Dav{\'e}}, Romeel and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Genel}, Shy},
-        title = "{The baryon cycle in modern cosmological hydrodynamical simulations}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = feb,
-          eid = {arXiv:2402.08408},
-        pages = {arXiv:2402.08408},
-          doi = {10.48550/arXiv.2402.08408},
-archivePrefix = {arXiv},
-       eprint = {2402.08408},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240208408W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv240205137H,
-       author = {{Ho}, Matthew and {Bartlett}, Deaglan J. and {Chartier}, Nicolas and {Cuesta-Lazaro}, Carolina and {Ding}, Simon and {Lapel}, Axel and {Lemos}, Pablo and {Lovell}, Christopher C. and {Makinen}, T. Lucas and {Modi}, Chirag and {Pandya}, Viraj and {Pandey}, Shivam and {Perez}, Lucia A. and {Wandelt}, Benjamin and {Bryan}, Greg L.},
-        title = "{LtU-ILI: An All-in-One Framework for Implicit Inference in Astrophysics and Cosmology}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Computer Science - Machine Learning},
-         year = 2024,
-        month = feb,
-          eid = {arXiv:2402.05137},
-        pages = {arXiv:2402.05137},
-          doi = {10.48550/arXiv.2402.05137},
-archivePrefix = {arXiv},
-       eprint = {2402.05137},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240205137H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
-}
-
-
-
-
-
-@ARTICLE{2024MNRAS.527.9683T,
-       author = {{Tan}, Brent and {Fielding}, Drummond B.},
-        title = "{Cloud atlas: navigating the multiphase landscape of tempestuous galactic winds}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {hydrodynamics, instabilities, turbulence, galaxies: clusters: general, galaxies: evolution, galaxies: haloes, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = feb,
-       volume = {527},
-       number = {4},
-        pages = {9683-9714},
-          doi = {10.1093/mnras/stad3793},
-archivePrefix = {arXiv},
-       eprint = {2305.14424},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.9683T},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024ApJS..270...36L,
-       author = {{Li}, Yin and {Modi}, Chirag and {Jamieson}, Drew and {Zhang}, Yucheng and {Lu}, Libin and {Feng}, Yu and {Lanusse}, Fran{\c{c}}ois and {Greengard}, Leslie},
-        title = "{Differentiable Cosmological Simulation with the Adjoint Method}",
-      journal = {The Astrophysical Journals},
-     keywords = {Cosmology, Large-scale structure of the universe, N-body simulations, Astronomy software, Computational methods, Algorithms, 343, 902, 1083, 1855, 1965, 1883, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = feb,
-       volume = {270},
-       number = {2},
-          eid = {36},
-        pages = {36},
-          doi = {10.3847/1538-4365/ad0ce7},
-archivePrefix = {arXiv},
-       eprint = {2211.09815},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJS..270...36L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...961..209B,
-       author = {{Bagley}, Micaela B. and {Finkelstein}, Steven L. and {Rojas-Ruiz}, Sof{\'\i}a and {Diekmann}, James and {Finkelstein}, Keely D. and {Song}, Mimi and {Papovich}, Casey and {Somerville}, Rachel S. and {Baronchelli}, Ivano and {Dai}, Y. Sophia},
-        title = "{Bright z {\ensuremath{\sim}} 9 Galaxies in Parallel: The Bright End of the Rest-frame UV Luminosity Function from HST Parallel Programs}",
-      journal = {The Astrophysical Journal},
-     keywords = {High-redshift galaxies, Galaxy evolution, Luminosity function, 734, 594, 942, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = feb,
-       volume = {961},
-       number = {2},
-          eid = {209},
-        pages = {209},
-          doi = {10.3847/1538-4357/ad09dc},
-archivePrefix = {arXiv},
-       eprint = {2205.12980},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...961..209B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240200110T,
-       author = {{To}, Chun-Hao and {Pandey}, Shivam and {Krause}, Elisabeth and {Dalal}, Nihar and {Anbajagane}, Dhayaa and {Weinberg}, David H.},
-        title = "{Deciphering baryonic feedback with galaxy clusters}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+@INPROCEEDINGS{2024icml.conf..212B,
+       author = {{Bourdin}, Antoine and {Legin}, Ronan and {Ho}, Matthew and {Adam}, Alexandre and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
+        title = "{Inpainting Galaxy Counts onto N-Body Simulations over Multiple Cosmologies and Astrophysics}",
+    booktitle = {ICML 2024 AI for Science Workshop},
          year = 2024,
         month = jan,
-          eid = {arXiv:2402.00110},
-        pages = {arXiv:2402.00110},
-          doi = {10.48550/arXiv.2402.00110},
-archivePrefix = {arXiv},
-       eprint = {2402.00110},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240200110T},
+          eid = {212},
+        pages = {212},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024icml.conf..212B},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-@ARTICLE{2024arXiv240118072P,
-       author = {{Pandey}, Shivam and {Salcido}, Jaime and {To}, Chun-Hao and {Hill}, J. Colin and {Anbajagane}, Dhayaa and {Baxter}, Eric J. and {McCarthy}, Ian G.},
-        title = "{GODMAX: Modeling gas thermodynamics and matter distribution using JAX}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-          eid = {arXiv:2401.18072},
-        pages = {arXiv:2401.18072},
-          doi = {10.48550/arXiv.2401.18072},
-archivePrefix = {arXiv},
-       eprint = {2401.18072},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240118072P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240117940L,
-       author = {{Lin}, Shurui and {Villaescusa-Navarro}, Francisco and {Rose}, Jonah and {Torrey}, Paul and {Farahi}, Arya and {Kollmann}, Kassidy E. and {Garcia}, Alex M. and {Roy}, Sandip and {Kallivayalil}, Nitya and {Vogelsberger}, Mark and {Cai}, Yi-Fu and {Luo}, Wentao},
-        title = "{Can we constrain warm dark matter masses with individual galaxies?}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = jan,
-          eid = {arXiv:2401.17940},
-        pages = {arXiv:2401.17940},
-          doi = {10.48550/arXiv.2401.17940},
-archivePrefix = {arXiv},
-       eprint = {2401.17940},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240117940L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv240108910B,
-       author = {{Baxter}, Eric J. and {Pandey}, Shivam},
-        title = "{Inferring galaxy cluster masses from cosmic microwave background lensing with neural simulation based inference}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2024,
-        month = jan,
-          eid = {arXiv:2401.08910},
-        pages = {arXiv:2401.08910},
-          doi = {10.48550/arXiv.2401.08910},
-archivePrefix = {arXiv},
-       eprint = {2401.08910},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240108910B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240106841C,
-       author = {{Cernetic}, Miha and {Springel}, Volker and {Guillet}, Thomas and {Pakmor}, R{\"u}diger},
-        title = "{Supersonic turbulence simulations with GPU-based high-order Discontinuous Galerkin hydrodynamics}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Physics - Fluid Dynamics},
-         year = 2024,
-        month = jan,
-          eid = {arXiv:2401.06841},
-        pages = {arXiv:2401.06841},
-          doi = {10.48550/arXiv.2401.06841},
-archivePrefix = {arXiv},
-       eprint = {2401.06841},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240106841C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @ARTICLE{2024MNRAS.527L.173L,
        author = {{Legin}, Ronan and {Ho}, Matthew and {Lemos}, Pablo and {Perreault-Levasseur}, Laurence and {Ho}, Shirley and {Hezaveh}, Yashar and {Wandelt}, Benjamin},
@@ -1514,87 +1577,8 @@ archivePrefix = {arXiv},
        eprint = {2304.03788},
  primaryClass = {astro-ph.CO},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527L.173L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
-}
-
-@ARTICLE{2024MNRAS.527.9461S,
-       author = {{Sharma}, Ray S. and {Choi}, Ena and {Somerville}, Rachel S. and {Snyder}, Gregory F. and {Jhee}, Hannah and {Kocevski}, Dale D. and {Hirschmann}, Michaela and {Moster}, Benjamin P. and {Naab}, Thorsten and {Narayanan}, Desika and {Ostriker}, Jeremiah P. and {Rosario}, David J.},
-        title = "{The connection between mergers and AGN activity in simulated and observed massive galaxies}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {quasars: general, galaxies: active, galaxies: interactions, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {3},
-        pages = {9461-9479},
-          doi = {10.1093/mnras/stad3836},
-archivePrefix = {arXiv},
-       eprint = {2101.01729},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.9461S},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-@ARTICLE{2024MNRAS.527.7847B,
-       author = {{Baxter}, Eric J. and {Pandey}, Shivam and {Adhikari}, Susmita and {Cui}, Weiguang and {Shin}, Tae-hyeon and {Li}, Qingyang and {Rasia}, Elena},
-        title = "{The impact of halo concentration on the Sunyaev Zel'dovich effect signal from massive galaxy clusters}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: clusters: general, galaxies: clusters: intracluster medium, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {3},
-        pages = {7847-7860},
-          doi = {10.1093/mnras/stad3704},
-archivePrefix = {arXiv},
-       eprint = {2304.08731},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.7847B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024MNRAS.527.7093J,
-       author = {{Jeffreson}, Sarah M.~R. and {Semenov}, Vadim A. and {Krumholz}, Mark R.},
-        title = "{Clouds of Theseus: long-lived molecular clouds are composed of short-lived H$_{2}$ molecules}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {ISM: clouds, ISM: evolution, ISM: structure, galaxies: star formation, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {3},
-        pages = {7093-7110},
-          doi = {10.1093/mnras/stad3550},
-archivePrefix = {arXiv},
-       eprint = {2301.10251},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.7093J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2024MNRAS.527.5929Y,
-       author = {{Yung}, L.~Y. Aaron and {Somerville}, Rachel S. and {Finkelstein}, Steven L. and {Wilkins}, Stephen M. and {Gardner}, Jonathan P.},
-        title = "{Are the ultra-high-redshift galaxies at z > 10 surprising in the context of standard galaxy formation models?}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: evolution, galaxies: formation, galaxies: high-redshift, galaxies: star formation, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {3},
-        pages = {5929-5948},
-          doi = {10.1093/mnras/stad3484},
-archivePrefix = {arXiv},
-       eprint = {2304.04348},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.5929Y},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
 
 @ARTICLE{ArkenstoneI,
        author = {{Smith}, Matthew C. and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Kim}, Chang-Goo and {Ostriker}, Eve C. and {Somerville}, Rachel S. and {Stern}, Jonathan and {Su}, Kung-Yi and {Weinberger}, Rainer and {Hu}, Chia-Yu and {Forbes}, John C. and {Hernquist}, Lars and {Burkhart}, Blakesley and {Li}, Yuan},
@@ -1611,83 +1595,8 @@ archivePrefix = {arXiv},
        eprint = {2301.07116},
  primaryClass = {astro-ph.GA},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.1216S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
-}
-
-@ARTICLE{ArkenstoneII,
-       author = {{Smith}, Matthew C. and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Bennett}, Jake S. and {Kim}, Chang-Goo and {Ostriker}, Eve C. and {Somerville}, Rachel S.},
-        title = "{Arkenstone -- II. A model for unresolved cool clouds entrained in galactic winds in cosmological simulations}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = aug,
-          eid = {arXiv:2408.15321},
-        pages = {arXiv:2408.15321},
-          doi = {10.48550/arXiv.2408.15321},
-archivePrefix = {arXiv},
-       eprint = {2408.15321},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240815321S},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-@ARTICLE{2024MNRAS.527.1033B,
-       author = {{Bennett}, Jake S. and {Sijacki}, Debora and {Costa}, Tiago and {Laporte}, Nicolas and {Witten}, Callum},
-        title = "{The growth of the gargantuan black holes powering high-redshift quasars and their impact on the formation of early galaxies and protoclusters}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: formation, galaxies: high-redshift, intergalactic medium, quasars: supermassive black holes, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {1},
-        pages = {1033-1054},
-          doi = {10.1093/mnras/stad3179},
-archivePrefix = {arXiv},
-       eprint = {2305.11932},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.1033B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024MNRAS.527..739R,
-       author = {{Rose}, Jonah C. and {Torrey}, Paul and {Villaescusa-Navarro}, Francisco and {Vogelsberger}, Mark and {O'Neil}, Stephanie and {Medvedev}, Mikhail V. and {Low}, Ryan and {Adhikari}, Rakshak and {Angl{\'e}s-Alc{\'a}zar}, Daniel},
-        title = "{Inferring warm dark matter masses with deep learning}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: halos, cosmological parameters, dark matter, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {1},
-        pages = {739-755},
-          doi = {10.1093/mnras/stad3260},
-archivePrefix = {arXiv},
-       eprint = {2304.14432},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527..739R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024MNRAS.527..265R,
-       author = {{Roy}, Manami and {Su}, Kung-Yi and {Tonnesen}, Stephanie and {Fielding}, Drummond B. and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e}},
-        title = "{Seeding the CGM: how satellites populate the cold phase of milky way haloes}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, Galaxy: halo, galaxies: evolution, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {527},
-       number = {1},
-        pages = {265-280},
-          doi = {10.1093/mnras/stad3142},
-archivePrefix = {arXiv},
-       eprint = {2310.04404},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.527..265R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @ARTICLE{2024ApJ...961...37C,
        author = {{Cochrane}, R.~K. and {Angl{\'e}s-Alc{\'a}zar}, D. and {Cullen}, F. and {Hayward}, C.~C.},
@@ -1727,78 +1636,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2024ApJ...960...54Z,
-       author = {{Zhu}, Jingyao and {Tonnesen}, Stephanie and {Bryan}, Greg L.},
-        title = "{When and How Ram Pressure Stripping in Low-mass Satellite Galaxies Enhances Star Formation}",
-      journal = {The Astrophysical Journal},
-     keywords = {Interstellar medium, Galaxy interactions, Star formation, Hydrodynamical simulations, 847, 600, 1569, 767, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {960},
-       number = {1},
-          eid = {54},
-        pages = {54},
-          doi = {10.3847/1538-4357/acfe6f},
-archivePrefix = {arXiv},
-       eprint = {2309.07037},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...960...54Z},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024ApJ...960...28V,
-       author = {{Voit}, G. Mark and {Oppenheimer}, Benjamin D. and {Bell}, Eric F. and {Terrazas}, Bryan and {Donahue}, Megan},
-        title = "{Black Hole Growth, Baryon Lifting, Star Formation, and IllustrisTNG}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy evolution, Circumgalactic medium, Supermassive black holes, Active galaxies, 594, 1879, 1663, 17, Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = jan,
-       volume = {960},
-       number = {1},
-          eid = {28},
-        pages = {28},
-          doi = {10.3847/1538-4357/ad0039},
-archivePrefix = {arXiv},
-       eprint = {2309.14818},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024ApJ...960...28V},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2023sf2a.conf..227F,
-       author = {{Farcy}, M. and {Rosdahl}, J. and {Dubois}, Y. and {Blaizot}, J. and {Martin-Alvarez}, S.},
-        title = "{The impact of cosmic ray feedback on the reionisation of the Universe}",
-     keywords = {galaxy evolution, cosmic ray feedback, epoch of reionisation},
-    booktitle = {SF2A-2023: Proceedings of the Annual meeting of the French Society of Astronomy and Astrophysics},
-         year = 2023,
-       editor = {{N'Diaye}, M. and {Siebert}, A. and {Lagarde}, N. and {Venot}, O. and {Bailli{\'e}e}, K. and {B{\'e}thermin}, M. and {Lagadec}, E. and {Malzac}, J. and {Richard}, J.},
-        month = dec,
-        pages = {227-230},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023sf2a.conf..227F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023arXiv231209271D,
-       author = {{Doeser}, Ludvig and {Jamieson}, Drew and {Stopyra}, Stephen and {Lavaux}, Guilhem and {Leclercq}, Florent and {Jasche}, Jens},
-        title = "{Bayesian Inference of Initial Conditions from Non-Linear Cosmic Structures using Field-Level Emulators}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = dec,
-          eid = {arXiv:2312.09271},
-        pages = {arXiv:2312.09271},
-          doi = {10.48550/arXiv.2312.09271},
-archivePrefix = {arXiv},
-       eprint = {2312.09271},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231209271D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
 @ARTICLE{2023MNRAS.526.5306D,
        author = {{Delgado}, Ana Maria and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Thiele}, Leander and {Pandey}, Shivam and {Lehman}, Kai and {Somerville}, Rachel S. and {Ntampaka}, Michelle and {Genel}, Shy and {Villaescusa-Navarro}, Francisco and {Hernquist}, Lars},
         title = "{Predicting the impact of feedback on matter clustering with machine learning in CAMELS}",
@@ -1817,60 +1654,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2023MNRAS.526.4613B,
-       author = {{Bevins}, Harry T.~J. and {Handley}, William J. and {Lemos}, Pablo and {Sims}, Peter H. and {de Lera Acedo}, Eloy and {Fialkov}, Anastasia and {Alsing}, Justin},
-        title = "{Marginal post-processing of Bayesian inference products with normalizing flows and kernel density estimators}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, methods: statistical, cosmic background radiation, dark ages, reionization, first stars, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = dec,
-       volume = {526},
-       number = {3},
-        pages = {4613-4626},
-          doi = {10.1093/mnras/stad2997},
-archivePrefix = {arXiv},
-       eprint = {2205.12841},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.4613B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.526.4520S,
-       author = {{Sethuram}, Snigdaa S. and {Cochrane}, Rachel K. and {Hayward}, Christopher C. and {Acquaviva}, Viviana and {Villaescusa-Navarro}, Francisco and {Popping}, Gerg{\"o} and {Wise}, John H.},
-        title = "{Emulating radiative transfer with artificial neural networks}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {radiative transfer, methods: statistical, galaxies: evolution, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = dec,
-       volume = {526},
-       number = {3},
-        pages = {4520-4528},
-          doi = {10.1093/mnras/stad2524},
-archivePrefix = {arXiv},
-       eprint = {2308.13648},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.4520S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.526.3610H,
-       author = {{Hirschmann}, Michaela and {Charlot}, Stephane and {Feltre}, Anna and {Curtis-Lake}, Emma and {Somerville}, Rachel S. and {Chevallard}, Jacopo and {Choi}, Ena and {Nelson}, Dylan and {Morisset}, Christophe and {Plat}, Adele and {Vidal-Garcia}, Alba},
-        title = "{Emission-line properties of IllustrisTNG galaxies: from local diagnostic diagrams to high-redshift predictions for JWST}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: active, galaxies: evolution, galaxies: high-redshift, galaxies: ISM, quasars: emission lines, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = dec,
-       volume = {526},
-       number = {3},
-        pages = {3610-3636},
-          doi = {10.1093/mnras/stad2955},
-archivePrefix = {arXiv},
-       eprint = {2212.02522},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.3610H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2023MNRAS.526.3504H,
        author = {{Hirschmann}, Michaela and {Charlot}, Stephane and {Somerville}, Rachel S.},
         title = "{High-redshift metallicity calibrations for JWST spectra: insights from line emission in cosmological simulations}",
@@ -1886,44 +1669,6 @@ archivePrefix = {arXiv},
        eprint = {2305.03753},
  primaryClass = {astro-ph.GA},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.3504H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MLS&T...4d5002L,
-       author = {{Lemos}, Pablo and {Jeffrey}, Niall and {Cranmer}, Miles and {Ho}, Shirley and {Battaglia}, Peter},
-        title = "{Rediscovering orbital mechanics with machine learning}",
-      journal = {Machine Learning: Science and Technology},
-     keywords = {scientific discovery, symbolic regression, AI scientist, graph neural network, inductive biases, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = dec,
-       volume = {4},
-       number = {4},
-          eid = {045002},
-        pages = {045002},
-          doi = {10.1088/2632-2153/acfa63},
-archivePrefix = {arXiv},
-       eprint = {2202.02306},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MLS&T...4d5002L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023JCAP...12..012M,
-       author = {{Massara}, Elena and {Villaescusa-Navarro}, Francisco and {Percival}, Will J.},
-        title = "{Predicting interloper fraction with graph neural networks}",
-      journal = {Journal of Cosmology and Astroparticle Physics},
-     keywords = {Machine learning, redshift surveys, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = dec,
-       volume = {2023},
-       number = {12},
-          eid = {012},
-        pages = {012},
-          doi = {10.1088/1475-7516/2023/12/012},
-archivePrefix = {arXiv},
-       eprint = {2309.05850},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023JCAP...12..012M},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -1946,27 +1691,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023AJ....166..228T,
-       author = {{Tillman}, Megan Taylor and {Burkhart}, Blakesley and {Tonnesen}, Stephanie and {Bird}, Simeon and {Bryan}, Greg L. and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Hassan}, Sultan and {Somerville}, Rachel S. and {Dav{\'e}}, Romeel and {Marinacci}, Federico and {Hernquist}, Lars and {Vogelsberger}, Mark},
-        title = "{An Exploration of AGN and Stellar Feedback Effects in the Intergalactic Medium via the Low-redshift Ly{\ensuremath{\alpha}} Forest}",
-      journal = {Astronomical Journal},
-     keywords = {Cosmology, Extragalactic astronomy, Intergalactic gas, Lyman alpha forest, Active galactic nuclei, Intergalactic medium, Stellar feedback, Supermassive black holes, 343, 506, 812, 980, 16, 813, 1602, 1663, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = dec,
-       volume = {166},
-       number = {6},
-          eid = {228},
-        pages = {228},
-          doi = {10.3847/1538-3881/ad02f5},
-archivePrefix = {arXiv},
-       eprint = {2307.06360},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023AJ....166..228T},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2023arXiv231118017P,
        author = {{Payot}, Nicolas and {Lemos}, Pablo and {Perreault-Levasseur}, Laurence and {Cuesta-Lazaro}, Carolina and {Modi}, Chirag and {Hezaveh}, Yashar},
         title = "{Learning an Effective Evolution Equation for Particle-Mesh Simulations Across Cosmologies}",
@@ -1981,40 +1705,6 @@ archivePrefix = {arXiv},
        eprint = {2311.18017},
  primaryClass = {astro-ph.CO},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231118017P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231118014R,
-       author = {{Rhea}, Carter and {Hlavacek-Larrondo}, Julie and {Kraft}, Ralph and {Bogdan}, Akos and {Adam}, Alexandre and {Perreault-Levasseur}, Laurence},
-        title = "{Unraveling the Mysteries of Galaxy Clusters: Recurrent Inference Deconvolution of X-ray Spectra}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.18014},
-        pages = {arXiv:2311.18014},
-          doi = {10.48550/arXiv.2311.18014},
-archivePrefix = {arXiv},
-       eprint = {2311.18014},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231118014R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231118012D,
-       author = {{Dia}, Noe and {Yantovski-Barth}, M.~J. and {Adam}, Alexandre and {Bowles}, Micah and {Lemos}, Pablo and {Scaife}, Anna M.~M. and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
-        title = "{Bayesian Imaging for Radio Interferometry with Score-Based Priors}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Computer Vision and Pattern Recognition},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.18012},
-        pages = {arXiv:2311.18012},
-          doi = {10.48550/arXiv.2311.18012},
-archivePrefix = {arXiv},
-       eprint = {2311.18012},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231118012D},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2035,92 +1725,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2023arXiv231118002A,
-       author = {{Adam}, Alexandre and {Stone}, Connor and {Bottrell}, Connor and {Legin}, Ronan and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
-        title = "{Echoes in the Noise: Posterior Samples of Faint Galaxy Surface Brightness Profiles with Score-Based Likelihoods and Priors}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Computer Vision and Pattern Recognition},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.18002},
-        pages = {arXiv:2311.18002},
-          doi = {10.48550/arXiv.2311.18002},
-archivePrefix = {arXiv},
-       eprint = {2311.18002},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231118002A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231117144B,
-       author = {{Bourne}, Martin A. and {Fiacconi}, Davide and {Sijacki}, Debora and {Piotrowska}, Joanna M. and {Koudmani}, Sophie},
-        title = "{Dynamics and spin alignment in massive, gravito-turbulent circumbinary discs around supermassive black hole binaries}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.17144},
-        pages = {arXiv:2311.17144},
-          doi = {10.48550/arXiv.2311.17144},
-archivePrefix = {arXiv},
-       eprint = {2311.17144},
- primaryClass = {astro-ph.HE},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231117144B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231116306P,
-       author = {{Pasquato}, Mario and {Haddad}, Syphax and {Di Cintio}, Pierfrancesco and {Adam}, Alexandre and {Lemos}, Pablo and {Dia}, No{\'e} and {Petrache}, Mircea and {Niccol{\`o} Di Carlo}, Ugo and {Trani}, Alessandro Alberto and {Perreault-Levasseur}, Laurence and {Hezaveh}, Yashar},
-        title = "{The search for the lost attractor}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Nonlinear Sciences - Chaotic Dynamics},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.16306},
-        pages = {arXiv:2311.16306},
-          doi = {10.48550/arXiv.2311.16306},
-archivePrefix = {arXiv},
-       eprint = {2311.16306},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231116306P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231116085P,
-       author = {{Prunier}, Marine and {Morr{\'a}s}, Gonzalo and {Nu{\~n}o Siles}, Jos{\'e} Francisco and {Clesse}, Sebastien and {Garc{\'\i}a-Bellido}, Juan and {Ruiz Morales}, Ester},
-        title = "{Analysis of the subsolar-mass black hole candidate SSM200308 from the second part of the third observing run of Advanced LIGO-Virgo}",
-      journal = {arXiv e-prints},
-     keywords = {General Relativity and Quantum Cosmology, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.16085},
-        pages = {arXiv:2311.16085},
-          doi = {10.48550/arXiv.2311.16085},
-archivePrefix = {arXiv},
-       eprint = {2311.16085},
- primaryClass = {gr-qc},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231116085P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023arXiv231108558P,
-       author = {{Park}, Core Francisco and {Ono}, Victoria and {Mudur}, Nayantara and {Ni}, Yueying and {Cuesta-Lazaro}, Carolina},
-        title = "{Probabilistic reconstruction of Dark Matter fields from biased tracers using diffusion models}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Computer Science - Artificial Intelligence},
-         year = 2023,
-        month = nov,
-          eid = {arXiv:2311.08558},
-        pages = {arXiv:2311.08558},
-          doi = {10.48550/arXiv.2311.08558},
-archivePrefix = {arXiv},
-       eprint = {2311.08558},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231108558P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2023arXiv231105742A,
        author = {{Alsing}, Justin and {Edwards}, Thomas D.~P. and {Wandelt}, Benjamin},
         title = "{Optimal simulation-based Bayesian decisions}",
@@ -2135,25 +1739,6 @@ archivePrefix = {arXiv},
        eprint = {2311.05742},
  primaryClass = {stat.ML},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231105742A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023OJAp....6E..42B,
-       author = {{Bartlett}, Deaglan J. and {Desmond}, Harry},
-        title = "{Marginalised Normal Regression: Unbiased curve fitting in the presence of x-errors}",
-      journal = {The Open Journal of Astrophysics},
-     keywords = {Statistics - Methodology, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = nov,
-       volume = {6},
-          eid = {42},
-        pages = {42},
-          doi = {10.21105/astro.2309.00948},
-archivePrefix = {arXiv},
-       eprint = {2309.00948},
- primaryClass = {stat.ME},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023OJAp....6E..42B},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2193,215 +1778,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023MNRAS.525.6312B,
-       author = {{Barrera}, Monica and {Springel}, Volker and {White}, Simon D.~M. and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Hernquist}, Lars and {Frenk}, Carlos and {Pakmor}, R{\"u}diger and {Ferlito}, Fulvio and {Hadzhiyska}, Boryana and {Delgado}, Ana Maria and {Kannan}, Rahul and {Bose}, Sownak},
-        title = "{The MillenniumTNG Project: semi-analytic galaxy formation models on the past lightcone}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: analytical, methods: numerical, galaxies: evolution, galaxies: formation, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = nov,
-       volume = {525},
-       number = {4},
-        pages = {6312-6335},
-          doi = {10.1093/mnras/stad2688},
-archivePrefix = {arXiv},
-       eprint = {2210.10419},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.525.6312B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023ApJ...958L...3H,
-       author = {{Hassan}, Sultan and {Lovell}, Christopher C. and {Madau}, Piero and {Huertas-Company}, Marc and {Somerville}, Rachel S. and {Burkhart}, Blakesley and {Dixon}, Keri L. and {Feldmann}, Robert and {Starkenburg}, Tjitske K. and {Wu}, John F. and {Jespersen}, Christian Kragh and {Gelfand}, Joseph D. and {Bera}, Ankita},
-        title = "{JWST Constraints on the UV Luminosity Density at Cosmic Dawn: Implications for 21 cm Cosmology}",
-      journal = {The Astrophysical Journall},
-     keywords = {Cosmology, James Webb Space Telescope, Radio interferometers, H I line emission, Early universe, 343, 2291, 1345, 690, 435, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = nov,
-       volume = {958},
-       number = {1},
-          eid = {L3},
-        pages = {L3},
-          doi = {10.3847/2041-8213/ad0239},
-archivePrefix = {arXiv},
-       eprint = {2305.02703},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...958L...3H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023A&A...679A..12M,
-       author = {{Markov}, V. and {Gallerani}, S. and {Pallottini}, A. and {Sommovigo}, L. and {Carniani}, S. and {Ferrara}, A. and {Parlanti}, E. and {Di Mascia}, F.},
-        title = "{Dust attenuation law in JWST galaxies at z {\ensuremath{\sim}} 7-8}",
-      journal = {Astronomy and Astrophysics},
-     keywords = {dust, extinction, Galaxy: evolution, Galaxy: fundamental parameters, galaxies: high-redshift, galaxies: ISM, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = nov,
-       volume = {679},
-          eid = {A12},
-        pages = {A12},
-          doi = {10.1051/0004-6361/202346723},
-archivePrefix = {arXiv},
-       eprint = {2304.11178},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023A&A...679A..12M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231017692S,
-       author = {{Su}, Kung-Yi and {Bryan}, Greg L. and {Hayward}, Christopher C. and {Somerville}, Rachel S. and {Hopkins}, Philip F. and {Emami}, Razieh and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e} and {Quataert}, Eliot and {Ponnada}, Sam B. and {Fielding}, Drummond and {Kere{\v{s}}}, Du{\v{s}}an},
-        title = "{Unraveling Jet Quenching Criteria Across L* Galaxies and Massive Cluster Ellipticals}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.17692},
-        pages = {arXiv:2310.17692},
-          doi = {10.48550/arXiv.2310.17692},
-archivePrefix = {arXiv},
-       eprint = {2310.17692},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231017692S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231015246H,
-       author = {{Hahn}, ChangHoon and {Lemos}, Pablo and {Parker}, Liam and {R{\'e}galdo-Saint Blancard}, Bruno and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Massara}, Elena and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {Spergel}, David},
-        title = "{${\rm S{\scriptsize IM}BIG}$: The First Cosmological Constraints from Non-Gaussian and Non-Linear Galaxy Clustering}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.15246},
-        pages = {arXiv:2310.15246},
-          doi = {10.48550/arXiv.2310.15246},
-archivePrefix = {arXiv},
-       eprint = {2310.15246},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231015246H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231015234D,
-       author = {{de Santi}, Natal{\'\i} S.~M. and {Villaescusa-Navarro}, Francisco and {Abramo}, L. Raul and {Shao}, Helen and {Perez}, Lucia A. and {Castro}, Tiago and {Ni}, Yueying and {Lovell}, Christopher C. and {Hernandez-Martinez}, Elena and {Marinacci}, Federico and {Spergel}, David N. and {Dolag}, Klaus and {Hernquist}, Lars and {Vogelsberger}, Mark},
-        title = "{Field-level simulation-based inference with galaxy catalogs: the impact of systematic effects}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Computer Science - Machine Learning},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.15234},
-        pages = {arXiv:2310.15234},
-          doi = {10.48550/arXiv.2310.15234},
-archivePrefix = {arXiv},
-       eprint = {2310.15234},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231015234D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023arXiv231011507P,
-       author = {{Porras-Valverde}, Antonio J. and {Forbes}, John C. and {Somerville}, Rachel S. and {Stevens}, Adam R.~H. and {Holley-Bockelmann}, Kelly and {Berlind}, Andreas A. and {Genel}, Shy},
-        title = "{Why do semi-analytic models predict higher scatter in the stellar mass-halo mass relation than cosmological hydrodynamic simulations?}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.11507},
-        pages = {arXiv:2310.11507},
-          doi = {10.48550/arXiv.2310.11507},
-archivePrefix = {arXiv},
-       eprint = {2310.11507},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231011507P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231011495S,
-       author = {{Steinwandel}, Ulrich P. and {Goldberg}, Jared A.},
-        title = "{Some stars fade quietly: Varied Supernova explosion outcomes and their effects on the multi-phase interstellar medium}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.11495},
-        pages = {arXiv:2310.11495},
-          doi = {10.48550/arXiv.2310.11495},
-archivePrefix = {arXiv},
-       eprint = {2310.11495},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231011495S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023arXiv231003083K,
-       author = {{Kurinchi-Vendhan}, Shalini and {Farcy}, Marion and {Hirschmann}, Michaela and {Valentino}, Francesco},
-        title = "{On the origin of star-formation quenching in massive galaxies at $z rsim 3$ in the cosmological simulations IllustrisTNG}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.03083},
-        pages = {arXiv:2310.03083},
-          doi = {10.48550/arXiv.2310.03083},
-archivePrefix = {arXiv},
-       eprint = {2310.03083},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231003083K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv231001315P,
-       author = {{Pandey}, Shivam and {S{\'a}nchez}, Carles and {Jain}, Bhuvnesh and {The LSST Dark Energy Science Collaboration}},
-        title = "{Cosmology with imaging galaxy surveys: the impact of evolving galaxy bias and magnification}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.01315},
-        pages = {arXiv:2310.01315},
-          doi = {10.48550/arXiv.2310.01315},
-archivePrefix = {arXiv},
-       eprint = {2310.01315},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231001315P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023PNAS..12018810H,
-       author = {{Hahn}, ChangHoon and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Lemos}, Pablo and {Massara}, Elena and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {Blancard}, Bruno R{\'e}galdo-Saint and {Abidi}, Muntazir M.},
-        title = "{A forward modeling approach to analyzing galaxy clustering with SIMBIG}",
-      journal = {Proceedings of the National Academy of Science},
-         year = 2023,
-        month = oct,
-       volume = {120},
-       number = {42},
-          eid = {e2218810120},
-        pages = {e2218810120},
-          doi = {10.1073/pnas.2218810120},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023PNAS..12018810H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023Obs...143..244B,
-       author = {{Bennett}, J.},
-        title = "{On the Evolution of Gaseous Haloes in Cosmological Simulations of Galax Formation}",
-      journal = {The Observatory},
-         year = 2023,
-        month = oct,
-       volume = {143},
-        pages = {244},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023Obs...143..244B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2023MNRAS.525.1779P,
        author = {{Pandey}, Shivam and {Lehman}, Kai and {Baxter}, Eric J. and {Ni}, Yueying and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Genel}, Shy and {Villaescusa-Navarro}, Francisco and {Delgado}, Ana Maria and {di Matteo}, Tiziana},
         title = "{Inferring the impact of feedback on the matter distribution using the Sunyaev Zel'dovich effect: insights from CAMELS simulations and ACT + DES data}",
@@ -2419,47 +1795,6 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.525.1779P},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-
-@ARTICLE{2023MNRAS.524.5591F,
-       author = {{Ferlito}, Fulvio and {Springel}, Volker and {Davies}, Christopher T. and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Pakmor}, R{\"u}diger and {Barrera}, Monica and {White}, Simon D.~M. and {Delgado}, Ana Maria and {Hadzhiyska}, Boryana and {Hernquist}, Lars and {Kannan}, Rahul and {Bose}, Sownak and {Frenk}, Carlos},
-        title = "{The MillenniumTNG Project: the impact of baryons and massive neutrinos on high-resolution weak gravitational lensing convergence maps}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {gravitational lensing: weak, methods: numerical, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = oct,
-       volume = {524},
-       number = {4},
-        pages = {5591-5606},
-          doi = {10.1093/mnras/stad2205},
-archivePrefix = {arXiv},
-       eprint = {2304.12338},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.5591F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023ApJ...956..149S,
-       author = {{Shao}, Helen and {de Santi}, Natal{\'\i} S.~M. and {Villaescusa-Navarro}, Francisco and {Teyssier}, Romain and {Ni}, Yueying and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Genel}, Shy and {Steinwandel}, Ulrich P. and {Hern{\'a}ndez-Mart{\'\i}nez}, Elena and {Dolag}, Klaus and {Lovell}, Christopher C. and {Garrison}, Lehman H. and {Visbal}, Eli and {Kulkarni}, Mihir and {Hernquist}, Lars and {Castro}, Tiago and {Vogelsberger}, Mark},
-        title = "{A Universal Equation to Predict {\ensuremath{\Omega}}$_{m}$ from Halo and Galaxy Catalogs}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmology, Cosmological parameters, Hydrodynamical simulations, 343, 339, 767, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = oct,
-       volume = {956},
-       number = {2},
-          eid = {149},
-        pages = {149},
-          doi = {10.3847/1538-4357/acee6f},
-archivePrefix = {arXiv},
-       eprint = {2302.14591},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...956..149S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @ARTICLE{2023ApJ...956..118P,
        author = {{Pandya}, Viraj and {Fielding}, Drummond B. and {Bryan}, Greg L. and {Carr}, Christopher and {Somerville}, Rachel S. and {Stern}, Jonathan and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e} and {Hafen}, Zachary and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Forbes}, John C.},
@@ -2480,259 +1815,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023ApJ...955..131W,
-       author = {{Wang}, Bonny Y. and {Pisani}, Alice and {Villaescusa-Navarro}, Francisco and {Wandelt}, Benjamin D.},
-        title = "{Machine-learning Cosmology from Void Properties}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmology, Voids, Large-scale structure of the universe, 343, 1779, 902, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = oct,
-       volume = {955},
-       number = {2},
-          eid = {131},
-        pages = {131},
-          doi = {10.3847/1538-4357/aceaf6},
-archivePrefix = {arXiv},
-       eprint = {2212.06860},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...955..131W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230915071M,
-       author = {{Modi}, Chirag and {Pandey}, Shivam and {Ho}, Matthew and {Hahn}, ChangHoon and {R'egaldo-Saint Blancard}, Bruno and {Wandelt}, Benjamin},
-        title = "{Sensitivity Analysis of Simulation-Based Inference for Galaxy Clustering}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-          eid = {arXiv:2309.15071},
-        pages = {arXiv:2309.15071},
-          doi = {10.48550/arXiv.2309.15071},
-archivePrefix = {arXiv},
-       eprint = {2309.15071},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230915071M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230912048C,
-       author = {{Chawak}, Chaitanya and {Villaescusa-Navarro}, Francisco and {Echeverri Rojas}, Nicolas and {Ni}, Yueying and {Hahn}, ChangHoon and {Angles-Alcazar}, Daniel},
-        title = "{Cosmology with multiple galaxies}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = sep,
-          eid = {arXiv:2309.12048},
-        pages = {arXiv:2309.12048},
-          doi = {10.48550/arXiv.2309.12048},
-archivePrefix = {arXiv},
-       eprint = {2309.12048},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230912048C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230910270M,
-       author = {{Modi}, Chirag and {Philcox}, Oliver H.~E.},
-        title = "{Hybrid SBI or How I Learned to Stop Worrying and Learn the Likelihood}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-          eid = {arXiv:2309.10270},
-        pages = {arXiv:2309.10270},
-          doi = {10.48550/arXiv.2309.10270},
-archivePrefix = {arXiv},
-       eprint = {2309.10270},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230910270M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230909337A,
-       author = {{Aubin}, Mayeul and {Cuesta-Lazaro}, Carolina and {Tregidga}, Ethan and {Via{\~n}a}, Javier and {Garraffo}, Cecilia and {Gordon}, Iouli E. and {L{\'o}pez-Morales}, Mercedes and {Hargreaves}, Robert J. and {Makhnev}, Vladimir Yu. and {Drake}, Jeremy J. and {Finkbeiner}, Douglas P. and {Cargile}, Phillip},
-        title = "{Simulation-based Inference for Exoplanet Atmospheric Retrieval: Insights from winning the Ariel Data Challenge 2023 using Normalizing Flows}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = sep,
-          eid = {arXiv:2309.09337},
-        pages = {arXiv:2309.09337},
-          doi = {10.48550/arXiv.2309.09337},
-archivePrefix = {arXiv},
-       eprint = {2309.09337},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230909337A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.4256M,
-       author = {{May}, Simon and {Springel}, Volker},
-        title = "{The halo mass function and filaments in full cosmological simulations with fuzzy dark matter}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: haloes, cosmology: theory, dark matter, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, General Relativity and Quantum Cosmology},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {3},
-        pages = {4256-4274},
-          doi = {10.1093/mnras/stad2031},
-archivePrefix = {arXiv},
-       eprint = {2209.14886},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.4256M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023MNRAS.524.3289H,
-       author = {{Ho}, Matthew and {Soltis}, John and {Farahi}, Arya and {Nagai}, Daisuke and {Evrard}, August and {Ntampaka}, Michelle},
-        title = "{Benchmarks and explanations for deep learning estimates of X-ray galaxy cluster masses}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, galaxies: clusters: general, galaxies: clusters: intracluster medium, galaxies: nuclei, large-scale structure of Universe, X-rays: galaxies: clusters, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {3},
-        pages = {3289-3302},
-          doi = {10.1093/mnras/stad2005},
-archivePrefix = {arXiv},
-       eprint = {2303.00005},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.3289H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2594K,
-       author = {{Kannan}, Rahul and {Springel}, Volker and {Hernquist}, Lars and {Pakmor}, R{\"u}diger and {Delgado}, Ana Maria and {Hadzhiyska}, Boryana and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Barrera}, Monica and {Ferlito}, Fulvio and {Bose}, Sownak and {White}, Simon D.~M. and {Frenk}, Carlos and {Smith}, Aaron and {Garaldi}, Enrico},
-        title = "{The MillenniumTNG project: the galaxy population at z {\ensuremath{\geq}} 8}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: formation, galaxies: evolution, cosmology: early Universe, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2594-2605},
-          doi = {10.1093/mnras/stac3743},
-archivePrefix = {arXiv},
-       eprint = {2210.10066},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2594K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2556H,
-       author = {{Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Springel}, Volker and {Pakmor}, R{\"u}diger and {Barrera}, Monica and {Ferlito}, Fulvio and {White}, Simon D.~M. and {Hernquist}, Lars and {Hadzhiyska}, Boryana and {Delgado}, Ana Maria and {Kannan}, Rahul and {Bose}, Sownak and {Frenk}, Carlos},
-        title = "{The MillenniumTNG Project: high-precision predictions for matter clustering and halo statistics}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: numerical, galaxies: haloes, large-scale structure of Universe, cosmology: theory, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2556-2578},
-          doi = {10.1093/mnras/stad1657},
-archivePrefix = {arXiv},
-       eprint = {2210.10059},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2556H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2539P,
-       author = {{Pakmor}, R{\"u}diger and {Springel}, Volker and {Coles}, Jonathan P. and {Guillet}, Thomas and {Pfrommer}, Christoph and {Bose}, Sownak and {Barrera}, Monica and {Delgado}, Ana Maria and {Ferlito}, Fulvio and {Frenk}, Carlos and {Hadzhiyska}, Boryana and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Hernquist}, Lars and {Kannan}, Rahul and {White}, Simon D.~M.},
-        title = "{The MillenniumTNG Project: the hydrodynamical full physics simulation and a first look at its galaxy clusters}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {hydrodynamics, methods: numerical, galaxies: clusters: general, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2539-2555},
-          doi = {10.1093/mnras/stac3620},
-archivePrefix = {arXiv},
-       eprint = {2210.10060},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2539P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2524H,
-       author = {{Hadzhiyska}, Boryana and {Hernquist}, Lars and {Eisenstein}, Daniel and {Delgado}, Ana Maria and {Bose}, Sownak and {Kannan}, Rahul and {Pakmor}, R{\"u}diger and {Springel}, Volker and {Contreras}, Sergio and {Barrera}, Monica and {Ferlito}, Fulvio and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {White}, Simon D.~M. and {Frenk}, Carlos},
-        title = "{The MillenniumTNG Project: refining the one-halo model of red and blue galaxies at different redshifts}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: haloes, large-scale structure of Universe, cosmology: theory, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2524-2538},
-          doi = {10.1093/mnras/stad279},
-archivePrefix = {arXiv},
-       eprint = {2210.10068},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2524H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2507H,
-       author = {{Hadzhiyska}, Boryana and {Eisenstein}, Daniel and {Hernquist}, Lars and {Pakmor}, R{\"u}diger and {Bose}, Sownak and {Delgado}, Ana Maria and {Contreras}, Sergio and {Kannan}, Rahul and {White}, Simon D.~M. and {Springel}, Volker and {Frenk}, Carlos and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Barrera}, Fulvio Ferlito and {Monica}},
-        title = "{The MillenniumTNG Project: an improved two-halo model for the galaxy-halo connection of red and blue galaxies}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: haloes, large-scale structure of Universe, cosmology: theory, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2507-2523},
-          doi = {10.1093/mnras/stad731},
-archivePrefix = {arXiv},
-       eprint = {2210.10072},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2507H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.524.2489C,
-       author = {{Contreras}, Sergio and {Angulo}, Raul E. and {Springel}, Volker and {White}, Simon D.~M. and {Hadzhiyska}, Boryana and {Hernquist}, Lars and {Pakmor}, R{\"u}diger and {Kannan}, Rahul and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {Barrera}, Monica and {Ferlito}, Fulvio and {Delgado}, Ana Maria and {Bose}, Sownak and {Frenk}, Carlos},
-        title = "{The MillenniumTNG Project: inferring cosmology from galaxy clustering with accelerated N-body scaling and subhalo abundance matching}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: formation, galaxies: statistics, large-scale structure of universe, cosmology: theory, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {524},
-       number = {2},
-        pages = {2489-2506},
-          doi = {10.1093/mnras/stac3699},
-archivePrefix = {arXiv},
-       eprint = {2210.10075},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.524.2489C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJ...954..125E,
-       author = {{Echeverri-Rojas}, Nicolas and {Villaescusa-Navarro}, Francisco and {Chawak}, Chaitanya and {Ni}, Yueying and {Hahn}, ChangHoon and {Hern{\'a}ndez-Mart{\'\i}nez}, Elena and {Teyssier}, Romain and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Dolag}, Klaus and {Castro}, Tiago},
-        title = "{Cosmology with One Galaxy? The ASTRID Model and Robustness}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmology, 343, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {954},
-       number = {2},
-          eid = {125},
-        pages = {125},
-          doi = {10.3847/1538-4357/ace96e},
-archivePrefix = {arXiv},
-       eprint = {2304.06084},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...954..125E},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2023ApJ...954...11P,
        author = {{Perez}, Lucia A. and {Genel}, Shy and {Villaescusa-Navarro}, Francisco and {Somerville}, Rachel S. and {Gabrielpillai}, Austen and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Wandelt}, Benjamin D. and {Yung}, L.~Y. Aaron},
         title = "{Constraining Cosmology with Machine Learning and Galaxy Clustering: The CAMELS-SAM Suite}",
@@ -2752,142 +1834,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023arXiv230805145N,
-       author = {{Nguyen}, Tri and {Modi}, Chirag and {Yung}, L.~Y. Aaron and {Somerville}, Rachel S.},
-        title = "{FLORAH: A generative model for halo assembly histories}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = aug,
-          eid = {arXiv:2308.05145},
-        pages = {arXiv:2308.05145},
-          doi = {10.48550/arXiv.2308.05145},
-archivePrefix = {arXiv},
-       eprint = {2308.05145},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230805145N},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.523.6082C,
-       author = {{Cochrane}, R.~K. and {Kondapally}, R. and {Best}, P.~N. and {Sabater}, J. and {Duncan}, K.~J. and {Smith}, D.~J.~B. and {Hardcastle}, M.~J. and {R{\"o}ttgering}, H.~J.~A. and {Prandoni}, I. and {Haskell}, P. and {G{\"u}rkan}, G. and {Miley}, G.~K.},
-        title = "{The LOFAR Two-metre Sky Survey: the radio view of the cosmic star formation history}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: evolution, galaxies: high redshift, galaxies: starburst, galaxies: star formation, radio continuum: galaxies, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = aug,
-       volume = {523},
-       number = {4},
-        pages = {6082-6102},
-          doi = {10.1093/mnras/stad1602},
-archivePrefix = {arXiv},
-       eprint = {2305.15510},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.6082C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.523.5899D,
-       author = {{Delgado}, Ana Maria and {Hadzhiyska}, Boryana and {Bose}, Sownak and {Springel}, Volker and {Hernquist}, Lars and {Barrera}, Monica and {Pakmor}, R{\"u}diger and {Ferlito}, Fulvio and {Kannan}, Rahul and {Hern{\'a}ndez-Aguayo}, C{\'e}sar and {White}, Simon D.~M. and {Frenk}, Carlos},
-        title = "{The MillenniumTNG project: intrinsic alignments of galaxies and haloes}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {gravitational lensing: weak, methods: numerical, large-scale structure of Universe, cosmology: theory, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = aug,
-       volume = {523},
-       number = {4},
-        pages = {5899-5914},
-          doi = {10.1093/mnras/stad1781},
-archivePrefix = {arXiv},
-       eprint = {2304.12346},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.5899D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023MNRAS.523.3219C,
-       author = {{Cuesta-Lazaro}, Carolina and {Nishimichi}, Takahiro and {Kobayashi}, Yosuke and {Ruan}, Cheng-Zong and {Eggemeier}, Alexander and {Miyatake}, Hironao and {Takada}, Masahiro and {Yoshida}, Naoki and {Zarrouk}, Pauline and {Baugh}, Carlton M. and {Bose}, Sownak and {Li}, Baojiu},
-        title = "{Galaxy clustering from the bottom up: a streaming model emulator I}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {cosmological parameters, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = aug,
-       volume = {523},
-       number = {3},
-        pages = {3219-3238},
-          doi = {10.1093/mnras/stad1207},
-archivePrefix = {arXiv},
-       eprint = {2208.05218},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.3219C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.523.2409C,
-       author = {{Cochrane}, R.~K. and {Angl{\'e}s-Alc{\'a}zar}, D. and {Mercedes-Feliz}, J. and {Hayward}, C.~C. and {Faucher-Gigu{\`e}re}, C. -A. and {Wellons}, S. and {Terrazas}, B.~A. and {Wetzel}, A. and {Hopkins}, P.~F. and {Moreno}, J. and {Su}, K. -Y. and {Somerville}, R.~S.},
-        title = "{The impact of AGN-driven winds on physical and observable galaxy sizes}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {radiative transfer, ISM: jets and outflows, galaxies: active, galaxies: evolution, quasars: supermassive black holes, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena},
-         year = 2023,
-        month = aug,
-       volume = {523},
-       number = {2},
-        pages = {2409-2421},
-          doi = {10.1093/mnras/stad1528},
-archivePrefix = {arXiv},
-       eprint = {2303.12858},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.2409C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023ApJ...952..145J,
-       author = {{Jamieson}, Drew and {Li}, Yin and {de Oliveira}, Renan Alves and {Villaescusa-Navarro}, Francisco and {Ho}, Shirley and {Spergel}, David N.},
-        title = "{Field-level Neural Network Emulator for Cosmological N-body Simulations}",
-      journal = {The Astrophysical Journal},
-     keywords = {Large-scale structure of the universe, 902, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = aug,
-       volume = {952},
-       number = {2},
-          eid = {145},
-        pages = {145},
-          doi = {10.3847/1538-4357/acdb6c},
-archivePrefix = {arXiv},
-       eprint = {2206.04594},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...952..145J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2023mla..confE..35W,
-       author = {{Wu}, John F. and {Jespersen}, Christian},
-        title = "{Learning the galaxy-environment connection with graph neural networks}",
-    booktitle = {Machine Learning for Astrophysics},
-         year = 2023,
-        month = jul,
-          eid = {35},
-        pages = {35},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mla..confE..35W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2023mla..confE..25N,
-       author = {{Nguyen}, Tri and {Modi}, Chirag and {Somerville}, Rachel and {Yung}, Aaron},
-        title = "{FLORAH: A generative model for halo assembly histories}",
-    booktitle = {Machine Learning for Astrophysics},
-         year = 2023,
-        month = jul,
-          eid = {25},
-        pages = {25},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mla..confE..25N},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @INPROCEEDINGS{2023mla..confE..21L,
        author = {{Lovell}, Christopher C. and {Hassan}, Sultan and {Villaescusa-Navarro}, Francisco and {Genel}, Shy and {Hahn}, ChangHoon and {Angles-Alcazar}, Daniel and {Kwon}, James and {de Santi}, Natali and {Iyer}, Kartheik and {Fabbian}, Giulio and {Bryan}, Greg},
         title = "{A Hierarchy of Normalizing Flows for Modelling the Galaxy-Halo Relationship}",
@@ -2902,23 +1848,6 @@ archivePrefix = {arXiv},
        eprint = {2307.06967},
  primaryClass = {astro-ph.GA},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023mla..confE..21L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2023mla..confE..18L,
-       author = {{Lemos}, Pablo and {Parker}, Liam H. and {Hahn}, ChangHoon and {Ho}, Shirley and {Eickenberg}, Michael and {Hou}, Jiamin and {Massara}, Elena and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {R{\'e}galdo-Saint Blancard}, Bruno and {Spergel}, David},
-        title = "{SimBIG: Field-level Simulation-based Inference of Large-scale Structure}",
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-    booktitle = {Machine Learning for Astrophysics},
-         year = 2023,
-        month = jul,
-          eid = {18},
-        pages = {18},
-          doi = {10.48550/arXiv.2310.15256},
-archivePrefix = {arXiv},
-       eprint = {2310.15256},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mla..confE..18L},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2951,72 +1880,29 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2023mla..confE..13H,
-       author = {{Hahn}, ChangHoon and {Lemos}, Pablo and {R{\'e}galdo-Saint Blancard}, Bruno and {Parker}, Liam H. and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Massara}, Elena and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {Spergel}, David},
-        title = "{SimBIG: Galaxy Clustering beyond the Power Spectrum}",
-    booktitle = {Machine Learning for Astrophysics},
+@INPROCEEDINGS{2023eas..conf..938K,
+       author = {{Koudmani}, Sophie and {Sijacki}, Debora and {Smith}, Matthew and {Somerville}, Rachel and {Jiang}, Yan-Fei},
+        title = "{Dormant relics or active players: exploring black hole formation and feedback in dwarf galaxies with cosmological simulations}",
+    booktitle = {EAS2023, European Astronomical Society Annual Meeting},
          year = 2023,
         month = jul,
-          eid = {13},
-        pages = {13},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mla..confE..13H},
+          eid = {938},
+        pages = {938},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023eas..conf..938K},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-
-@ARTICLE{2023arXiv230713083L,
-       author = {{Lemos}, Pablo and {Shah}, Paul},
-        title = "{The Cosmic Microwave Background and $H_0$}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+@INPROCEEDINGS{2023eas..conf..932K,
+       author = {{Koudmani}, Sophie and {Bourne}, Martin and {Sijacki}, Debora and {Somerville}, Rachel and {Jiang}, Yan-Fei},
+        title = "{Supermassive black hole binaries on a moving mesh: the crucial role of accretion disc models for multi-messenger predictions}",
+    booktitle = {EAS2023, European Astronomical Society Annual Meeting},
          year = 2023,
         month = jul,
-          eid = {arXiv:2307.13083},
-        pages = {arXiv:2307.13083},
-          doi = {10.48550/arXiv.2307.13083},
-archivePrefix = {arXiv},
-       eprint = {2307.13083},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230713083L},
+          eid = {932},
+        pages = {932},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023eas..conf..932K},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-@ARTICLE{2023arXiv230707555T,
-       author = {{Thiele}, Leander and {Massara}, Elena and {Pisani}, Alice and {Hahn}, ChangHoon and {Spergel}, David N. and {Ho}, Shirley and {Wandelt}, Benjamin},
-        title = "{Neutrino mass constraint from an Implicit Likelihood Analysis of BOSS voids}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jul,
-          eid = {arXiv:2307.07555},
-        pages = {arXiv:2307.07555},
-          doi = {10.48550/arXiv.2307.07555},
-archivePrefix = {arXiv},
-       eprint = {2307.07555},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230707555T},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230703228A,
-       author = {{Abruzzo}, Matthew W. and {Fielding}, Drummond B. and {Bryan}, Greg L.},
-        title = "{TuRMoiL of Survival: A Unified Survival Criterion for Cloud-Wind Interactions}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = jul,
-          eid = {arXiv:2307.03228},
-        pages = {arXiv:2307.03228},
-          doi = {10.48550/arXiv.2307.03228},
-archivePrefix = {arXiv},
-       eprint = {2307.03228},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230703228A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @ARTICLE{2023MNRAS.523.1104W,
        author = {{Weinberger}, Rainer and {Su}, Kung-Yi and {Ehlert}, Kristian and {Pfrommer}, Christoph and {Hernquist}, Lars and {Bryan}, Greg L. and {Springel}, Volker and {Li}, Yuan and {Burkhart}, Blakesley and {Choi}, Ena and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e}},
@@ -3035,108 +1921,6 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.1104W},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-
-@ARTICLE{2023ApJ...952...69D,
-       author = {{de Santi}, Natal{\'\i} S.~M. and {Shao}, Helen and {Villaescusa-Navarro}, Francisco and {Abramo}, L. Raul and {Teyssier}, Romain and {Villanueva-Domingo}, Pablo and {Ni}, Yueying and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Genel}, Shy and {Hern{\'a}ndez-Mart{\'\i}nez}, Elena and {Steinwandel}, Ulrich P. and {Lovell}, Christopher C. and {Dolag}, Klaus and {Castro}, Tiago and {Vogelsberger}, Mark},
-        title = "{Robust Field-level Likelihood-free Inference with Galaxies}",
-      journal = {The Astrophysical Journal},
-     keywords = {Magnetohydrodynamical simulations, Astrostatistics, Cosmological parameters, Cosmology, Hydrodynamical simulations, 1966, 1882, 339, 343, 767, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Computer Science - Machine Learning},
-         year = 2023,
-        month = jul,
-       volume = {952},
-       number = {1},
-          eid = {69},
-        pages = {69},
-          doi = {10.3847/1538-4357/acd1e2},
-archivePrefix = {arXiv},
-       eprint = {2302.14101},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...952...69D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@
-@ARTICLE{2023ApJ...951...70M,
-       author = {{Massara}, Elena and {Villaescusa-Navarro}, Francisco and {Hahn}, ChangHoon and {Abidi}, Muntazir M. and {Eickenberg}, Michael and {Ho}, Shirley and {Lemos}, Pablo and {Dizgah}, Azadeh Moradinezhad and {Blancard}, Bruno R{\'e}galdo-Saint},
-        title = "{Cosmological Information in the Marked Power Spectrum of the Galaxy Field}",
-      journal = {The Astrophysical Journal},
-     keywords = {Large-scale structure of the universe, Cosmology, Cosmological parameters, 902, 343, 339, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jul,
-       volume = {951},
-       number = {1},
-          eid = {70},
-        pages = {70},
-          doi = {10.3847/1538-4357/acd44d},
-archivePrefix = {arXiv},
-       eprint = {2206.01709},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...951...70M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023ApJ...951....6A,
-       author = {{Adam}, Alexandre and {Perreault-Levasseur}, Laurence and {Hezaveh}, Yashar and {Welling}, Max},
-        title = "{Pixelated Reconstruction of Foreground Density and Background Surface Brightness in Gravitational Lensing Systems Using Recurrent Inference Machines}",
-      journal = {The Astrophysical Journal},
-     keywords = {Convolutional neural networks, Astronomical simulations, Nonparametric inference, 1938, 1857, 1903, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Computer Vision and Pattern Recognition},
-         year = 2023,
-        month = jul,
-       volume = {951},
-       number = {1},
-          eid = {6},
-        pages = {6},
-          doi = {10.3847/1538-4357/accf84},
-archivePrefix = {arXiv},
-       eprint = {2301.04168},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...951....6A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2023MNRAS.522.2707S,
-       author = {{Siwek}, Magdalena and {Weinberger}, Rainer and {Hernquist}, Lars},
-        title = "{Orbital evolution of binaries in circumbinary discs}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {accretion, accretion discs, hydrodynamics, quasars: supermassive black holes, (transients:) black hole mergers, gravitational waves, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Solar and Stellar Astrophysics},
-         year = 2023,
-        month = jun,
-       volume = {522},
-       number = {2},
-        pages = {2707-2717},
-          doi = {10.1093/mnras/stad1131},
-archivePrefix = {arXiv},
-       eprint = {2302.01785},
- primaryClass = {astro-ph.HE},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.522.2707S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.522.2628W,
-       author = {{Wadekar}, Digvijay and {Thiele}, Leander and {Hill}, J. Colin and {Pandey}, Shivam and {Villaescusa-Navarro}, Francisco and {Spergel}, David N. and {Cranmer}, Miles and {Nagai}, Daisuke and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Ho}, Shirley and {Hernquist}, Lars},
-        title = "{The SZ flux-mass (Y-M) relation at low-halo masses: improvements with symbolic regression and strong constraints on baryonic feedback}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: clusters: general - galaxies: groups: general - cosmic background radiation, large-scale structure of Universe, cosmology: observations, methods: data analysis, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Artificial Intelligence, Computer Science - Machine Learning},
-         year = 2023,
-        month = jun,
-       volume = {522},
-       number = {2},
-        pages = {2628-2643},
-          doi = {10.1093/mnras/stad1128},
-archivePrefix = {arXiv},
-       eprint = {2209.02075},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.522.2628W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 
 @ARTICLE{2023JCAP...06..046B,
        author = {{Bayer}, Adrian E. and {Modi}, Chirag and {Ferraro}, Simone},
@@ -3157,88 +1941,10 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023ApJ...950..159Z,
-       author = {{Zhang}, Yucheng and {Pullen}, Anthony R. and {Somerville}, Rachel S. and {Breysse}, Patrick C. and {Forbes}, John C. and {Yang}, Shengqi and {Li}, Yin and {Maniyar}, Abhishek S.},
-        title = "{Characterizing the Conditional Galaxy Property Distribution Using Gaussian Mixture Models}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy evolution, Line intensities, Astrostatistics strategies, Astrostatistics distributions, Gaussian mixture model, 594, 2084, 1885, 1884, 1937, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jun,
-       volume = {950},
-       number = {2},
-          eid = {159},
-        pages = {159},
-          doi = {10.3847/1538-4357/accb90},
-archivePrefix = {arXiv},
-       eprint = {2302.11166},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...950..159Z},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJ...950..132H,
-       author = {{Hu}, Chia-Yu and {Smith}, Matthew C. and {Teyssier}, Romain and {Bryan}, Greg L. and {Verbeke}, Robbert and {Emerick}, Andrew and {Somerville}, Rachel S. and {Burkhart}, Blakesley and {Li}, Yuan and {Forbes}, John C. and {Starkenburg}, Tjitske},
-        title = "{Code Comparison in Galaxy-scale Simulations with Resolved Supernova Feedback: Lagrangian versus Eulerian Methods}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy formation, Stellar feedback, Hydrodynamical simulations, 595, 1602, 767, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = jun,
-       volume = {950},
-       number = {2},
-          eid = {132},
-        pages = {132},
-          doi = {10.3847/1538-4357/accf9e},
-archivePrefix = {arXiv},
-       eprint = {2208.10528},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...950..132H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJ...950...91C,
-       author = {{Chen}, Zirui and {Fielding}, Drummond B. and {Bryan}, Greg L.},
-        title = "{The Anatomy of a Turbulent Radiative Mixing Layer: Insights from an Analytic Model with Turbulent Conduction and Viscosity}",
-      journal = {The Astrophysical Journal},
-     keywords = {Circumgalactic medium, Galactic winds, Galaxies, Galaxy evolution, Galaxy physics, Galactic and extragalactic astronomy, 1879, 572, 573, 594, 612, 563, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = jun,
-       volume = {950},
-       number = {2},
-          eid = {91},
-        pages = {91},
-          doi = {10.3847/1538-4357/acc73f},
-archivePrefix = {arXiv},
-       eprint = {2211.01395},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...950...91C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJ...950...70G,
-       author = {{Giusarma}, Elena and {Reyes}, Mauricio and {Villaescusa-Navarro}, Francisco and {He}, Siyu and {Ho}, Shirley and {Hahn}, ChangHoon},
-        title = "{Learning Neutrino Effects in Cosmology with Convolutional Neural Network}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmology, Cosmological parameters from large-scale structure, Cosmological neutrinos, Large-scale structure of the universe, N-body simulations, 343, 340, 338, 902, 1083, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning, High Energy Physics - Phenomenology},
-         year = 2023,
-        month = jun,
-       volume = {950},
-       number = {1},
-          eid = {70},
-        pages = {70},
-          doi = {10.3847/1538-4357/accd61},
-archivePrefix = {arXiv},
-       eprint = {1910.04255},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...950...70G},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2023ApJ...949L..41L,
        author = {{Legin}, Ronan and {Adam}, Alexandre and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
         title = "{Beyond Gaussian Noise: A Generalized Approach to Likelihood Analysis with Non-Gaussian Noise}",
-      journal = {The Astrophysical Journall},
+      journal = {The Astrophysical Journal Letters},
      keywords = {James Webb Space Telescope, Hubble Space Telescope, Non-Gaussianity, Astronomy image processing, Observational astronomy, Bayesian statistics, CCD observation, Cosmic rays, Posterior distribution, Neural networks, Astronomy data analysis, Computational methods, 2291, 761, 1116, 2306, 1145, 1900, 207, 329, 1926, 1933, 1858, 1965, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2023,
         month = jun,
@@ -3253,44 +1959,6 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...949L..41L},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-
-
-@ARTICLE{2023PhRvD.107j3505L,
-       author = {{Lemos}, Pablo and {Lewis}, Antony},
-        title = "{CMB constraints on the early Universe independent of late-time cosmology}",
-      journal = {Physical Review D},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = may,
-       volume = {107},
-       number = {10},
-          eid = {103505},
-        pages = {103505},
-          doi = {10.1103/PhysRevD.107.103505},
-archivePrefix = {arXiv},
-       eprint = {2302.12911},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023PhRvD.107j3505L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023PhRvD.107j3003V,
-       author = {{Villanueva-Domingo}, Pablo and {Villaescusa-Navarro}, Francisco and {Genel}, Shy and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Hernquist}, Lars and {Marinacci}, Federico and {Spergel}, David N. and {Vogelsberger}, Mark and {Narayanan}, Desika},
-        title = "{Weighing the Milky Way and Andromeda galaxies with artificial intelligence}",
-      journal = {Physical Review D},
-         year = 2023,
-        month = may,
-       volume = {107},
-       number = {10},
-          eid = {103003},
-        pages = {103003},
-          doi = {10.1103/PhysRevD.107.103003},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023PhRvD.107j3003V},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 
 @ARTICLE{2023ApJ...949...21C,
        author = {{Carr}, Christopher and {Bryan}, Greg L. and {Fielding}, Drummond B. and {Pandya}, Viraj and {Somerville}, Rachel S.},
@@ -3311,62 +1979,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023ApJ...948..107F,
-       author = {{Forbes}, John C. and {Emami}, Razieh and {Somerville}, Rachel S. and {Genel}, Shy and {Nelson}, Dylan and {Pillepich}, Annalisa and {Burkhart}, Blakesley and {Bryan}, Greg L. and {Krumholz}, Mark R. and {Hernquist}, Lars and {Tonnesen}, Stephanie and {Torrey}, Paul and {Pandya}, Viraj and {Hayward}, Christopher C.},
-        title = "{Gas Accretion Can Drive Turbulence in Galaxies}",
-      journal = {The Astrophysical Journal},
-     keywords = {Galaxy physics, Galaxy processes, Galaxy dynamics, Galaxy formation, High-redshift galaxies, Disk galaxies, Star formation, 612, 614, 591, 595, 734, 391, 1569, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = may,
-       volume = {948},
-       number = {2},
-          eid = {107},
-        pages = {107},
-          doi = {10.3847/1538-4357/acb53e},
-archivePrefix = {arXiv},
-       eprint = {2204.05344},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...948..107F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023arXiv230406333B,
-       author = {{Bartlett}, Deaglan J. and {Desmond}, Harry and {Ferreira}, Pedro G.},
-        title = "{Priors for symbolic regression}",
-      journal = {arXiv e-prints},
-     keywords = {Computer Science - Machine Learning, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = apr,
-          eid = {arXiv:2304.06333},
-        pages = {arXiv:2304.06333},
-          doi = {10.48550/arXiv.2304.06333},
-archivePrefix = {arXiv},
-       eprint = {2304.06333},
- primaryClass = {cs.LG},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230406333B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230405928T,
-       author = {{Thiele}, Leander and {Marques}, Gabriela A. and {Liu}, Jia and {Shirasaki}, Masato},
-        title = "{Cosmological constraints from HSC Y1 lensing convergence PDF}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = apr,
-          eid = {arXiv:2304.05928},
-        pages = {arXiv:2304.05928},
-          doi = {10.48550/arXiv.2304.05928},
-archivePrefix = {arXiv},
-       eprint = {2304.05928},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230405928T},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
 @ARTICLE{2023MNRAS.520.5746A,
        author = {{Andrews}, Adam and {Jasche}, Jens and {Lavaux}, Guilhem and {Schmidt}, Fabian},
         title = "{Bayesian field-level inference of primordial non-Gaussianity using next-generation galaxy surveys}",
@@ -3382,10 +1994,8 @@ archivePrefix = {arXiv},
        eprint = {2203.08838},
  primaryClass = {astro-ph.CO},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.520.5746A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-      selected = {true}
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
 
 @ARTICLE{2023MNRAS.520.4258S,
        author = {{Su}, Kung-Yi and {Bryan}, Greg L. and {Haiman}, Zolt{\'a}n and {Somerville}, Rachel S. and {Hayward}, Christopher C. and {Faucher-Gigu{\`e}re}, Claude-Andr{\'e}},
@@ -3405,269 +2015,18 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023MNRAS.520.3767G,
-       author = {{Genina}, A. and {Deason}, A.~J. and {Frenk}, C.~S.},
-        title = "{On the edge: the relation between stellar and dark matter haloes of Milky Way-mass galaxies}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {Galaxy: formation, Galaxy: halo, dark matter, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = apr,
-       volume = {520},
-       number = {3},
-        pages = {3767-3787},
-          doi = {10.1093/mnras/stad397},
-archivePrefix = {arXiv},
-       eprint = {2208.02266},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.520.3767G},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023MNRAS.520.1630K,
-       author = {{Karmakar}, Tathagata and {Genel}, Shy and {Somerville}, Rachel S.},
-        title = "{The relationship between galaxy and halo sizes in the Illustris and IllustrisTNG simulations}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies : formation, galaxies: evolution, galaxies: haloes, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = apr,
-       volume = {520},
-       number = {2},
-        pages = {1630-1641},
-          doi = {10.1093/mnras/stad178},
-archivePrefix = {arXiv},
-       eprint = {2301.10409},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.520.1630K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023JCAP...04..010H,
-       author = {{Hahn}, ChangHoon and {Eickenberg}, Michael and {Ho}, Shirley and {Hou}, Jiamin and {Lemos}, Pablo and {Massara}, Elena and {Modi}, Chirag and {Moradinezhad Dizgah}, Azadeh and {R{\'e}galdo-Saint Blancard}, Bruno and {Abidi}, Muntazir M.},
-        title = "{SIMBIG: mock challenge for a forward modeling approach to galaxy clustering}",
+@ARTICLE{2023JCAP...04E..02M,
+       author = {{Makinen}, T. Lucas and {Charnock}, Tom and {Alsing}, Justin and {Wandelt}, Benjamin D.},
+        title = "{Erratum: Lossless, scalable implicit likelihood inference for cosmological fields}",
       journal = {Journal of Cosmology and Astroparticle Physics},
-     keywords = {cosmological parameters from LSS, redshift surveys, cosmological simulations, Machine learning, Astrophysics - Cosmology and Nongalactic Astrophysics},
          year = 2023,
         month = apr,
        volume = {2023},
        number = {4},
-          eid = {010},
-        pages = {010},
-          doi = {10.1088/1475-7516/2023/04/010},
-archivePrefix = {arXiv},
-       eprint = {2211.00660},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023JCAP...04..010H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJS..265...54V,
-       author = {{Villaescusa-Navarro}, Francisco and {Genel}, Shy and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Perez}, Lucia A. and {Villanueva-Domingo}, Pablo and {Wadekar}, Digvijay and {Shao}, Helen and {Mohammad}, Faizan G. and {Hassan}, Sultan and {Moser}, Emily and {Lau}, Erwin T. and {Machado Poletti Valle}, Luis Fernando and {Nicola}, Andrina and {Thiele}, Leander and {Jo}, Yongseok and {Philcox}, Oliver H.~E. and {Oppenheimer}, Benjamin D. and {Tillman}, Megan and {Hahn}, ChangHoon and {Kaushal}, Neerav and {Pisani}, Alice and {Gebhardt}, Matthew and {Delgado}, Ana Maria and {Caliendo}, Joyce and {Kreisch}, Christina and {Wong}, Kaze W.~K. and {Coulton}, William R. and {Eickenberg}, Michael and {Parimbelli}, Gabriele and {Ni}, Yueying and {Steinwandel}, Ulrich P. and {La Torre}, Valentina and {Dave}, Romeel and {Battaglia}, Nicholas and {Nagai}, Daisuke and {Spergel}, David N. and {Hernquist}, Lars and {Burkhart}, Blakesley and {Narayanan}, Desika and {Wandelt}, Benjamin and {Somerville}, Rachel S. and {Bryan}, Greg L. and {Viel}, Matteo and {Li}, Yin and {Irsic}, Vid and {Kraljic}, Katarina and {Marinacci}, Federico and {Vogelsberger}, Mark},
-        title = "{The CAMELS Project: Public Data Release}",
-      journal = {The Astrophysical Journals},
-     keywords = {Cosmology, Hydrodynamical simulations, Astrostatistics, Galaxy formation, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Artificial Intelligence, Computer Science - Machine Learning},
-         year = 2023,
-        month = apr,
-       volume = {265},
-       number = {2},
-          eid = {54},
-        pages = {54},
-          doi = {10.3847/1538-4365/acbf47},
-archivePrefix = {arXiv},
-       eprint = {2201.01300},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJS..265...54V},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023arXiv230317939B,
-       author = {{Boonkongkird}, Chotipan and {Lavaux}, Guilhem and {Peirani}, Sebastien and {Dubois}, Yohan and {Porqueres}, Natalia and {Tsaprazi}, Eleni},
-        title = "{LyAl-Net: A high-efficiency Lyman-$\alpha$ forest simulation with a neural network}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Physics - Data Analysis, Statistics and Probability},
-         year = 2023,
-        month = mar,
-          eid = {arXiv:2303.17939},
-        pages = {arXiv:2303.17939},
-          doi = {10.48550/arXiv.2303.17939},
-archivePrefix = {arXiv},
-       eprint = {2303.17939},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230317939B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230313056J,
-       author = {{Jindal}, Vaibhav and {Liang}, Albert and {Singh}, Aarti and {Ho}, Shirley and {Jamieson}, Drew},
-        title = "{Predicting the Initial Conditions of the Universe using a Deterministic Neural Network}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = mar,
-          eid = {arXiv:2303.13056},
-        pages = {arXiv:2303.13056},
-          doi = {10.48550/arXiv.2303.13056},
-archivePrefix = {arXiv},
-       eprint = {2303.13056},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230313056J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023arXiv230307473A,
-       author = {{Andrianomena}, Sambatra and {Hassan}, Sultan and {Villaescusa-Navarro}, Francisco},
-        title = "{Invertible mapping between fields in CAMELS}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = mar,
-          eid = {arXiv:2303.07473},
-        pages = {arXiv:2303.07473},
-          doi = {10.48550/arXiv.2303.07473},
-archivePrefix = {arXiv},
-       eprint = {2303.07473},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230307473A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2023MNRAS.520..668P,
-       author = {{Piras}, Davide and {Joachimi}, Benjamin and {Villaescusa-Navarro}, Francisco},
-        title = "{Fast and realistic large-scale structure from machine-learning-augmented random field simulations}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: statistical, software: simulations, large-scale structure of Universe, dark matter, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = mar,
-       volume = {520},
-       number = {1},
-        pages = {668-683},
-          doi = {10.1093/mnras/stad052},
-archivePrefix = {arXiv},
-       eprint = {2205.07898},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.520..668P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.520..461J,
-       author = {{Jahn}, Ethan D. and {Sales}, Laura V. and {Marinacci}, Federico and {Vogelsberger}, Mark and {Torrey}, Paul and {Qi}, Jia and {Smith}, Aaron and {Li}, Hui and {Kannan}, Rahul and {Burger}, Jan D. and {Zavala}, Jes{\'u}s},
-        title = "{Real and counterfeit cores: how feedback expands haloes and disrupts tracers of inner gravitational potential in dwarf galaxies}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: dwarf, galaxies: haloes, galaxies: kinematics and dynamics, galaxies: structure, dark matter, cosmology: theory, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = mar,
-       volume = {520},
-       number = {1},
-        pages = {461-479},
-          doi = {10.1093/mnras/stad109},
-archivePrefix = {arXiv},
-       eprint = {2110.00142},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.520..461J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.519.5775L,
-       author = {{Lemos}, Pablo and {Agarwal}, Jessica and {Schr{\"o}ter}, Matthias},
-        title = "{Distribution and dynamics of decimetre-sized dust agglomerates in the coma of 67P/Churyumov-Gerasimenko}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, methods: numerical, comets: individual: 67P/Churyumov-Gerasimenko, Astrophysics - Earth and Planetary Astrophysics},
-         year = 2023,
-        month = mar,
-       volume = {519},
-       number = {4},
-        pages = {5775-5786},
-          doi = {10.1093/mnras/stad032},
-archivePrefix = {arXiv},
-       eprint = {2301.04895},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.519.5775L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023MLS&T...4aLT01L,
-       author = {{Lemos}, Pablo and {Cranmer}, Miles and {Abidi}, Muntazir and {Hahn}, ChangHoon and {Eickenberg}, Michael and {Massara}, Elena and {Yallup}, David and {Ho}, Shirley},
-        title = "{Robust simulation-based inference in cosmology with Bayesian neural networks}",
-      journal = {Machine Learning: Science and Technology},
-     keywords = {cosmology, machine learning, likelihood free, implicit likelihood, simulation based, inference, DELFI, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = mar,
-       volume = {4},
-       number = {1},
-          eid = {01LT01},
-        pages = {01LT01},
-          doi = {10.1088/2632-2153/acbb53},
-archivePrefix = {arXiv},
-       eprint = {2207.08435},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MLS&T...4aLT01L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023JCAP...03..059M,
-       author = {{Modi}, Chirag and {Li}, Yin and {Blei}, David},
-        title = "{Reconstructing the universe with variational self-boosted sampling}",
-      journal = {Journal of Cosmology and Astroparticle Physics},
-     keywords = {cosmological parameters from LSS, cosmological simulations, Machine learning, Statistical sampling techniques, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Statistics - Machine Learning},
-         year = 2023,
-        month = mar,
-       volume = {2023},
-       number = {3},
-          eid = {059},
-        pages = {059},
-          doi = {10.1088/1475-7516/2023/03/059},
-archivePrefix = {arXiv},
-       eprint = {2206.15433},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023JCAP...03..059M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023JCAP...03..039B,
-       author = {{Bolliet}, Boris and {Colin Hill}, J. and {Ferraro}, Simone and {Kusiak}, Aleksandra and {Krolewski}, Alex},
-        title = "{Projected-field kinetic Sunyaev-Zel'dovich Cross-correlations: halo model and forecasts}",
-      journal = {Journal of Cosmology and Astroparticle Physics},
-     keywords = {CMBR theory, galaxy surveys, semi-analytic modeling, Sunyaev-Zeldovich effect, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = mar,
-       volume = {2023},
-       number = {3},
-          eid = {039},
-        pages = {039},
-          doi = {10.1088/1475-7516/2023/03/039},
-archivePrefix = {arXiv},
-       eprint = {2208.07847},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023JCAP...03..039B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJS..265...23K,
-       author = {{Kwon}, K.~J. and {Hahn}, ChangHoon and {Alsing}, Justin},
-        title = "{Neural Stellar Population Synthesis Emulator for the DESI PROVABGS}",
-      journal = {The Astrophysical Journals},
-     keywords = {Galaxies, Astronomy data modeling, Neural networks, Spectral energy distribution, 573, 1859, 1933, 2129, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = mar,
-       volume = {265},
-       number = {1},
-          eid = {23},
-        pages = {23},
-          doi = {10.3847/1538-4365/acba14},
-archivePrefix = {arXiv},
-       eprint = {2209.14323},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJS..265...23K},
+          eid = {E02},
+        pages = {E02},
+          doi = {10.1088/1475-7516/2023/04/E02},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023JCAP...04E..02M},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3709,84 +2068,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2023ApJ...945L..17T,
-       author = {{Tillman}, Megan Taylor and {Burkhart}, Blakesley and {Tonnesen}, Stephanie and {Bird}, Simeon and {Bryan}, Greg L. and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Dav{\'e}}, Romeel and {Genel}, Shy},
-        title = "{Efficient Long-range Active Galactic Nuclei (AGNs) Feedback Affects the Low-redshift Ly{\ensuremath{\alpha}} Forest}",
-      journal = {The Astrophysical Journall},
-     keywords = {Cosmology, Extragalactic astronomy, Intergalactic gas, Lyman alpha forest, Active galactic nuclei, Astrophysical black holes, 343, 506, 812, 980, 16, 98, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = mar,
-       volume = {945},
-       number = {1},
-          eid = {L17},
-        pages = {L17},
-          doi = {10.3847/2041-8213/acb7f1},
-archivePrefix = {arXiv},
-       eprint = {2210.02467},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...945L..17T},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023MNRAS.519.3011W,
-       author = {{Weinberger}, R. and {Hernquist}, L.},
-        title = "{Modelling multiphase gases in cosmological simulations using compressible multifluid hydrodynamics}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {equation of state, hydrodynamics, methods: numerical, software: development, galaxies: ISM, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = feb,
-       volume = {519},
-       number = {2},
-        pages = {3011-3026},
-          doi = {10.1093/mnras/stac3708},
-archivePrefix = {arXiv},
-       eprint = {2204.05316},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.519.3011W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.519.2155S,
-       author = {{Scoggins}, Matthew T. and {Haiman}, Zolt{\'a}n and {Wise}, John H.},
-        title = "{How long do high redshift massive black hole seeds remain outliers in black hole versus host galaxy relations?}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: haloes, galaxies: high-redshift, quasars: supermassive black holes, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = feb,
-       volume = {519},
-       number = {2},
-        pages = {2155-2168},
-          doi = {10.1093/mnras/stac3715},
-archivePrefix = {arXiv},
-       eprint = {2205.09611},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.519.2155S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.519.1887S,
-       author = {{Skarbinski}, Maya and {Jeffreson}, Sarah M.~R. and {Goodman}, Alyssa A.},
-        title = "{Building the molecular cloud population: the role of cloud mergers}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {ISM: bubbles, ISM: clouds, ISM: evolution, ISM: structure, Galaxies: star formation, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = feb,
-       volume = {519},
-       number = {2},
-        pages = {1887-1898},
-          doi = {10.1093/mnras/stac3627},
-archivePrefix = {arXiv},
-       eprint = {2212.01396},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.519.1887S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
 @ARTICLE{2023MNRAS.518.5522C,
        author = {{Cochrane}, R.~K. and {Hayward}, C.~C. and {Angl{\'e}s-Alc{\'a}zar}, D. and {Somerville}, R.~S.},
         title = "{Predicting sub-millimetre flux densities from global galaxy properties}",
@@ -3804,7 +2085,6 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.518.5522C},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
 
 @ARTICLE{2023ApJ...944...67J,
        author = {{Jo}, Yongseok and {Genel}, Shy and {Wandelt}, Benjamin and {Somerville}, Rachel S. and {Villaescusa-Navarro}, Francisco and {Bryan}, Greg L. and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Foreman-Mackey}, Daniel and {Nelson}, Dylan and {Kim}, Ji-hoon},
@@ -3825,192 +2105,27 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2023ApJ...944...27S,
-       author = {{Shao}, Helen and {Villaescusa-Navarro}, Francisco and {Villanueva-Domingo}, Pablo and {Teyssier}, Romain and {Garrison}, Lehman H. and {Gatti}, Marco and {Inman}, Derek and {Ni}, Yueying and {Steinwandel}, Ulrich P. and {Kulkarni}, Mihir and {Visbal}, Eli and {Bryan}, Greg L. and {Angl{\'e}s-Alc{\'a}zar}, Daniel and {Castro}, Tiago and {Hern{\'a}ndez-Mart{\'\i}nez}, Elena and {Dolag}, Klaus},
-        title = "{Robust Field-level Inference of Cosmological Parameters with Dark Matter Halos}",
-      journal = {The Astrophysical Journal},
-     keywords = {Cosmology, Sigma8, Density parameters, Cosmological parameters from large-scale structure, 343, 1455, 372, 340},
-         year = 2023,
-        month = feb,
-       volume = {944},
-       number = {1},
-          eid = {27},
-        pages = {27},
-          doi = {10.3847/1538-4357/acac7a},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...944...27S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023ApJ...943..128S,
-       author = {{Sheng}, Ming-Jie and {Yu}, Hao-Ran and {Li}, Sijia and {Liao}, Shihong and {Du}, Min and {Wang}, Yunchong and {Wang}, Peng and {Xu}, Kun and {Genel}, Shy and {Irodotou}, Dimitrios},
-        title = "{Baryonic Effects on Lagrangian Clustering and Angular Momentum Reconstruction}",
-      journal = {The Astrophysical Journal},
-     keywords = {Initial conditions of the universe, Cosmological evolution, Galaxy dark matter halos, Galaxy rotation, Clustering, 795, 336, 1880, 618, 1908, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = feb,
-       volume = {943},
-       number = {2},
-          eid = {128},
-        pages = {128},
-          doi = {10.3847/1538-4357/acae92},
-archivePrefix = {arXiv},
-       eprint = {2210.04203},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...943..128S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023arXiv230103581T,
-       author = {{Tsaprazi}, Eleni and {Jasche}, Jens and {Lavaux}, Guilhem and {Leclercq}, Florent},
-        title = "{Higher-order statistics of the large-scale structure from photometric redshifts}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+@INPROCEEDINGS{2023mlps.work76177P,
+       author = {{Payot}, Nicolas and {Pasquato}, Mario and {Trani}, Alessandro Alberto and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
+        title = "{Active learning meets fractal decision boundaries: a cautionary tale from the Sitnikov three-body problem}",
+    booktitle = {Machine Learning and the Physical Sciences Workshop},
          year = 2023,
         month = jan,
-          eid = {arXiv:2301.03581},
-        pages = {arXiv:2301.03581},
-          doi = {10.48550/arXiv.2301.03581},
-archivePrefix = {arXiv},
-       eprint = {2301.03581},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230103581T},
+        pages = {76177},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mlps.work76177P},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2023RASTI...2...78F,
-       author = {{Ferreras}, Ignacio and {Lahav}, Ofer and {Somerville}, Rachel S. and {Silk}, Joseph},
-        title = "{The entropy of galaxy spectra: how much information is encoded?}",
-      journal = {RAS Techniques and Instruments},
-     keywords = {galaxies: stellar content, methods: data analysis, methods: statistical, techniques: spectroscopic, Astrophysics - Astrophysics of Galaxies, Physics - Data Analysis, Statistics and Probability},
+@INPROCEEDINGS{2023mlps.work..177P,
+       author = {{Payot}, Nicolas and {Lemos}, Pablo and {Perreault-Levasseur}, Laurence and {Cuesta-Lazaro}, Carolina and {Modi}, Chirag and {Hezaveh}, Yashar},
+        title = "{Learning an Effective Evolution Equation for Particle-Mesh Simulations Across Cosmologies}",
+    booktitle = {Machine Learning and the Physical Sciences Workshop},
          year = 2023,
         month = jan,
-       volume = {2},
-       number = {1},
-        pages = {78-90},
-          doi = {10.1093/rasti/rzad004},
-archivePrefix = {arXiv},
-       eprint = {2208.05489},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023RASTI...2...78F},
+        pages = {177},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023mlps.work..177P},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-@ARTICLE{ho2023information,
-       author = {{Ho}, Matthew and {Zhao}, Xiaosheng and {Wandelt}, Benjamin},
-        title = "{Information-Ordered Bottlenecks for Adaptive Semantic Compression}",
-      journal = {arXiv e-prints},
-     keywords = {Computer Science - Machine Learning},
-         year = 2023,
-        month = may,
-          eid = {arXiv:2305.11213},
-        pages = {arXiv:2305.11213},
-          doi = {10.48550/arXiv.2305.11213},
-archivePrefix = {arXiv},
-       eprint = {2305.11213},
- primaryClass = {cs.LG},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230511213H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023PMLR..20219256L,
-       author = {{Lemos}, Pablo and {Coogan}, Adam and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence},
-        title = "{Sampling-Based Accuracy Testing of Posterior Estimators for General Inference}",
-      journal = {40th International Conference on Machine Learning},
-     keywords = {Statistics - Machine Learning, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning, Statistics - Methodology},
-         year = 2023,
-        month = jan,
-       volume = {202},
-        pages = {19256-19273},
-          doi = {10.48550/arXiv.2302.03026},
-archivePrefix = {arXiv},
-       eprint = {2302.03026},
- primaryClass = {stat.ML},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023PMLR..20219256L},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-@ARTICLE{2023MNRAS.518.4622E,
-       author = {{Ehlert}, K. and {Weinberger}, R. and {Pfrommer}, C. and {Pakmor}, R. and {Springel}, V.},
-        title = "{Self-regulated AGN feedback of light jets in cool-core galaxy clusters}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {MHD, methods: numerical, galaxies: active, galaxies: clusters: intracluster medium, galaxies: jets, Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jan,
-       volume = {518},
-       number = {3},
-        pages = {4622-4645},
-          doi = {10.1093/mnras/stac2860},
-archivePrefix = {arXiv},
-       eprint = {2204.01765},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.518.4622E},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2023MNRAS.518.4191P,
-       author = {{Prideaux-Ghee}, James and {Leclercq}, Florent and {Lavaux}, Guilhem and {Heavens}, Alan and {Jasche}, Jens},
-        title = "{Field-based physical inference from peculiar velocity tracers}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, galaxies: distances and redshifts, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jan,
-       volume = {518},
-       number = {3},
-        pages = {4191-4213},
-          doi = {10.1093/mnras/stac3346},
-archivePrefix = {arXiv},
-       eprint = {2204.00023},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.518.4191P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023MNRAS.518.2567G,
-       author = {{Gerardi}, Francesca and {Cuceu}, Andrei and {Font-Ribera}, Andreu and {Joachimi}, Benjamin and {Lemos}, Pablo},
-        title = "{Direct cosmological inference from three-dimensional correlations of the Lyman {\ensuremath{\alpha}} forest}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, cosmological parameters, large-scale structure of universe, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jan,
-       volume = {518},
-       number = {2},
-        pages = {2567-2573},
-          doi = {10.1093/mnras/stac3257},
-archivePrefix = {arXiv},
-       eprint = {2209.11263},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.518.2567G},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2023ApJS..264...10K,
-       author = {{Kim}, Jeong-Gyu and {Gong}, Munan and {Kim}, Chang-Goo and {Ostriker}, Eve C.},
-        title = "{Photochemistry and Heating/Cooling of the Multiphase Interstellar Medium with UV Radiative Transfer for Magnetohydrodynamic Simulations}",
-      journal = {The Astrophysical Journals},
-     keywords = {Interstellar phases, Astrochemistry, Hydrodynamical simulations, Radiative magnetohydrodynamics, Interstellar radiation field, Photodissociation regions, H II regions, Supernova remnants, 850, 75, 767, 2009, 852, 1223, 694, 1667, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2023,
-        month = jan,
-       volume = {264},
-       number = {1},
-          eid = {10},
-        pages = {10},
-          doi = {10.3847/1538-4365/ac9b1d},
-archivePrefix = {arXiv},
-       eprint = {2210.08024},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJS..264...10K},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @ARTICLE{2023ApJ...943....4L,
        author = {{Legin}, Ronan and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence and {Wandelt}, Benjamin},
@@ -4031,446 +2146,3 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-
-@ARTICLE{fb2022,
-       author = {{Fielding}, Drummond B. and {Bryan}, Greg L.},
-        title = "{The Structure of Multiphase Galactic Winds}",
-      journal = {Astrophysical Journal},
-     keywords = {572, 573, 594, 612, 563, 1879, Astrophysics - Astrophysics of Galaxies},
-         year = 2022,
-        month = jan,
-       volume = {924},
-       number = {2},
-          eid = {82},
-        pages = {82},
-          doi = {10.3847/1538-4357/ac2f41},
-archivePrefix = {arXiv},
-       eprint = {2108.05355},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2022ApJ...924...82F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Jeffreson2024,
-       author = {{Jeffreson}, Sarah M.~R. and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Gensior}, Jindra and {Bryan}, Greg L. and {Davis}, Timothy A. and {Hernquist}, Lars and {Hassan}, Sultan},
-        title = "{Learning the Universe: GalactISM simulations of resolved star formation and galactic outflows across main sequence and quenched galactic environments}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies},
-         year = 2024,
-        month = sep,
-          eid = {arXiv:2409.09114},
-        pages = {arXiv:2409.09114},
-          doi = {10.48550/arXiv.2409.09114},
-archivePrefix = {arXiv},
-       eprint = {2409.09114},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240909114J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{Hassan2024,
-       author = {{Hassan}, Sultan and {Ostriker}, Eve C. and {Kim}, Chang-Goo and {Bryan}, Greg L. and {Burger}, Jan D. and {Fielding}, Drummond B. and {Forbes}, John C. and {Genel}, Shy and {Hernquist}, Lars and {Jeffreson}, Sarah M.~R. and {Motwani}, Bhawna and {Smith}, Matthew C. and {Somerville}, Rachel S. and {Steinwandel}, Ulrich P. and {Teyssier}, Romain},
-        title = "{Towards Implementation of the Pressure-Regulated, Feedback-Modulated Model of Star Formation in Cosmological Simulations: Methods and Application to TNG}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2024,
-        month = sep,
-          eid = {arXiv:2409.09121},
-        pages = {arXiv:2409.09121},
-          doi = {10.48550/arXiv.2409.09121},
-archivePrefix = {arXiv},
-       eprint = {2409.09121},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240909121H},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{Pfeifer:2023,
-       author = {{Pfeifer}, Simon and {Valade}, Aur{\'e}lien and {Gottl{\"o}ber}, Stefan and {Hoffman}, Yehuda and {Libeskind}, Noam I. and {Hellwing}, Wojciech A.},
-        title = "{A local universe model for constrained simulations}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {cosmology: large-scale structure of Universe, methods: numerical, techniques: radial velocities, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2023,
-        month = aug,
-       volume = {523},
-       number = {4},
-        pages = {5985-5994},
-          doi = {10.1093/mnras/stad1851},
-archivePrefix = {arXiv},
-       eprint = {2305.05694},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.523.5985P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{PrideauxGhee:2023,
-       author = {{Prideaux-Ghee}, James and {Leclercq}, Florent and {Lavaux}, Guilhem and {Heavens}, Alan and {Jasche}, Jens},
-        title = "{Field-based physical inference from peculiar velocity tracers}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {methods: data analysis, galaxies: distances and redshifts, large-scale structure of Universe, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = jan,
-       volume = {518},
-       number = {3},
-        pages = {4191-4213},
-          doi = {10.1093/mnras/stac3346},
-archivePrefix = {arXiv},
-       eprint = {2204.00023},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.518.4191P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Boruah:2022,
-       author = {{Boruah}, Supranta S. and {Lavaux}, Guilhem and {Hudson}, Michael J.},
-        title = "{Bayesian reconstruction of dark matter distribution from peculiar velocities: accounting for inhomogeneous Malmquist bias}",
-      journal = {Monthly Notices of the Royal Astronomical Society},
-     keywords = {galaxies: kinematics and dynamics, large-scale structure of Universe, cosmology: observations, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2022,
-        month = dec,
-       volume = {517},
-       number = {3},
-        pages = {4529-4543},
-          doi = {10.1093/mnras/stac2985},
-archivePrefix = {arXiv},
-       eprint = {2111.15535},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2022MNRAS.517.4529B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{McAlpine:2024,
-     author = {{McAlpine}, Stuart and {Jasche}, Jens and {Ata}, Metin and {Lavaux}, Guilhem and {Stiskalek}, Richard and {Frenk}, Carlos S. and {Jenkins}, Adrian},
-        title = "{The Manticore Project I: a digital twin of our cosmic neighbourhood from Bayesian field-level analysis}",
-      journal = {\mnras},
-     keywords = {galaxies: clusters: general, galaxies: distances and redshifts, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics},
-         year = 2025,
-        month = jun,
-       volume = {540},
-       number = {1},
-        pages = {716-745},
-          doi = {10.1093/mnras/staf767},
-archivePrefix = {arXiv},
-       eprint = {2505.10682},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.540..716M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Boonkongkird:2023,
-       author = {{Boonkongkird}, Chotipan and {Lavaux}, Guilhem and {Peirani}, Sebastien and {Dubois}, Yohan and {Porqueres}, Natalia and {Tsaprazi}, Eleni},
-        title = "{LyAl-Net: A high-efficiency Lyman-$\alpha$ forest simulation with a neural network}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Physics - Data Analysis, Statistics and Probability},
-         year = 2023,
-        month = mar,
-          eid = {arXiv:2303.17939},
-        pages = {arXiv:2303.17939},
-          doi = {10.48550/arXiv.2303.17939},
-archivePrefix = {arXiv},
-       eprint = {2303.17939},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv230317939B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Doeser:2023,
-       author = {{Doeser}, Ludvig and {Jamieson}, Drew and {Stopyra}, Stephen and {Lavaux}, Guilhem and {Leclercq}, Florent and {Jasche}, Jens},
-        title = "{Bayesian Inference of Initial Conditions from Non-Linear Cosmic Structures using Field-Level Emulators}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = dec,
-          eid = {arXiv:2312.09271},
-        pages = {arXiv:2312.09271},
-          doi = {10.48550/arXiv.2312.09271},
-archivePrefix = {arXiv},
-       eprint = {2312.09271},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231209271D},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{Jamieson:2023,
-       author = {{Jamieson}, Drew and {Li}, Yin and {de Oliveira}, Renan Alves and {Villaescusa-Navarro}, Francisco and {Ho}, Shirley and {Spergel}, David N.},
-        title = "{Field-level Neural Network Emulator for Cosmological N-body Simulations}",
-      journal = {The Astrophysical Journal},
-     keywords = {Large-scale structure of the universe, 902, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning},
-         year = 2023,
-        month = aug,
-       volume = {952},
-       number = {2},
-          eid = {145},
-        pages = {145},
-          doi = {10.3847/1538-4357/acdb6c},
-archivePrefix = {arXiv},
-       eprint = {2206.04594},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJ...952..145J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{Bartlett:2024,
-       author = {{Bartlett}, Deaglan J. and {Chiarenza}, Marco and {Doeser}, Ludvig and {Leclercq}, Florent},
-        title = "{COmoving Computer Acceleration (COCA): $N$-body simulations in an emulated frame of reference}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning, Statistics - Machine Learning},
-         year = 2024,
-        month = sep,
-          eid = {arXiv:2409.02154},
-        pages = {arXiv:2409.02154},
-          doi = {10.48550/arXiv.2409.02154},
-archivePrefix = {arXiv},
-       eprint = {2409.02154},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240902154B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv241014623S,
-       author = {{Sui}, Ce and {Bartlett}, Deaglan J. and {Pandey}, Shivam and {Desmond}, Harry and {Ferreira}, Pedro G. and {Wandelt}, Benjamin D.},
-        title = "{syren-new: Precise formulae for the linear and nonlinear matter power spectra with massive neutrinos and dynamical dark energy}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Machine Learning, Computer Science - Neural and Evolutionary Computing},
-         year = 2024,
-        month = oct,
-          eid = {arXiv:2410.14623},
-        pages = {arXiv:2410.14623},
-archivePrefix = {arXiv},
-       eprint = {2410.14623},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv241014623S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-
-
-@ARTICLE{2022OJAp....5E..18M,
-       author = {{Makinen}, T. Lucas and {Charnock}, Tom and {Lemos}, Pablo and {Porqueres}, Natalia and {Heavens}, Alan F. and {Wandelt}, Benjamin D.},
-        title = "{The Cosmic Graph: Optimal Information Extraction from Large-Scale Structure using Catalogues}",
-      journal = {The Open Journal of Astrophysics},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Statistics - Machine Learning},
-         year = 2022,
-        month = dec,
-       volume = {5},
-       number = {1},
-          eid = {18},
-        pages = {18},
-          doi = {10.21105/astro.2207.05202},
-archivePrefix = {arXiv},
-       eprint = {2207.05202},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2022OJAp....5E..18M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2023arXiv231003812M,
-       author = {{Makinen}, T. Lucas and {Alsing}, Justin and {Wandelt}, Benjamin D.},
-        title = "{Fishnets: Information-Optimal, Scalable Aggregation for Sets and Graphs}",
-      journal = {arXiv e-prints},
-     keywords = {Computer Science - Machine Learning, Statistics - Machine Learning},
-         year = 2023,
-        month = oct,
-          eid = {arXiv:2310.03812},
-        pages = {arXiv:2310.03812},
-          doi = {10.48550/arXiv.2310.03812},
-archivePrefix = {arXiv},
-       eprint = {2310.03812},
- primaryClass = {cs.LG},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023arXiv231003812M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2024arXiv240718909M,
-       author = {{Makinen}, T. Lucas and {Heavens}, Alan and {Porqueres}, Natalia and {Charnock}, Tom and {Lapel}, Axel and {Wandelt}, Benjamin D.},
-        title = "{Hybrid summary statistics: neural weak lensing inference beyond the power spectrum}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Machine Learning, Physics - Computational Physics, Statistics - Machine Learning, Statistics - Other Statistics},
-         year = 2024,
-        month = jul,
-          eid = {arXiv:2407.18909},
-        pages = {arXiv:2407.18909},
-          doi = {10.48550/arXiv.2407.18909},
-archivePrefix = {arXiv},
-       eprint = {2407.18909},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240718909M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2024arXiv241007548M,
-       author = {{Makinen}, T. Lucas and {Sui}, Ce and {Wandelt}, Benjamin D. and {Porqueres}, Natalia and {Heavens}, Alan},
-        title = "{Hybrid Summary Statistics}",
-      journal = {arXiv e-prints},
-     keywords = {Statistics - Machine Learning, Astrophysics - Cosmology and Nongalactic Astrophysics, Computer Science - Information Theory, Computer Science - Machine Learning, Physics - Data Analysis, Statistics and Probability},
-         year = 2024,
-        month = oct,
-          eid = {arXiv:2410.07548},
-        pages = {arXiv:2410.07548},
-          doi = {10.48550/arXiv.2410.07548},
-archivePrefix = {arXiv},
-       eprint = {2410.07548},
- primaryClass = {stat.ML},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv241007548M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-@ARTICLE{2024arXiv240909124P,
-       author = {{Pandey}, Shivam and {Modi}, Chirag and {Wandelt}, Benjamin D. and {Bartlett}, Deaglan J. and {Bayer}, Adrian E. and {Bryan}, Greg L. and {Ho}, Matthew and {Lavaux}, Guilhem and {Makinen}, T. Lucas and {Villaescusa-Navarro}, Francisco},
-        title = "{CHARM: Creating Halos with Auto-Regressive Multi-stage networks}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Statistics - Machine Learning},
-         year = 2024,
-        month = sep,
-          eid = {arXiv:2409.09124},
-        pages = {arXiv:2409.09124},
-          doi = {10.48550/arXiv.2409.09124},
-archivePrefix = {arXiv},
-       eprint = {2409.09124},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240909124P},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Farcy2025,
-       author = {{Farcy}, Marion and {Hirschmann}, Michaela and {Somerville}, Rachel S. and {Choi}, Ena and {Koudmani}, Sophie and {Naab}, Thorsten and {Weinberger}, Rainer and {Bennett}, Jake S. and {Bhowmick}, Aklant K. and {Choi}, Hyunseop and {Hernquist}, Lars and {Hlavacek-Larrondo}, Julie and {Terrazas}, Bryan A. and {Valentino}, Francesco},
-        title = "{MISTRAL: a model for AGN winds from radiatively efficient accretion in cosmological simulations}",
-      journal = {\mnras},
-     keywords = {methods: numerical, galaxies: active, galaxies: evolution, galaxies: formation, Astrophysics of Galaxies},
-         year = 2025,
-        month = oct,
-       volume = {543},
-       number = {2},
-        pages = {967-993},
-          doi = {10.1093/mnras/staf1464},
-archivePrefix = {arXiv},
-       eprint = {2504.08041},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2025MNRAS.543..967F},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2025arXiv250213240S,
-       author = {{Sommovigo}, Laura and {Cochrane}, Rachel K. and {Somerville}, Rachel S. and {Hayward}, Christopher C. and {Lovell}, Christopher C. and {Starkenburg}, Tjitske and {Popping}, Gerg{\"o} and {Iyer}, Kartheik and {Gabrielpillai}, Austen and {Ho}, Matthew and {Steinwandel}, Ulrich P. and {Perez}, Lucia A.},
-        title = "{Learning the Universe: physically-motivated priors for dust attenuation curves}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2025,
-        month = feb,
-          eid = {arXiv:2502.13240},
-        pages = {arXiv:2502.13240},
-          doi = {10.48550/arXiv.2502.13240},
-archivePrefix = {arXiv},
-       eprint = {2502.13240},
- primaryClass = {astro-ph.GA},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250213240S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2025arXiv250213239J,
-       author = {{Jo}, Yongseok and {Genel}, Shy and {Sengupta}, Anirvan and {Wandelt}, Benjamin and {Somerville}, Rachel and {Villaescusa-Navarro}, Francisco},
-        title = "{Towards Robustness Across Cosmological Simulation Models TNG, SIMBA, ASTRID, and EAGLE}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-         year = 2025,
-        month = feb,
-          eid = {arXiv:2502.13239},
-        pages = {arXiv:2502.13239},
-          doi = {10.48550/arXiv.2502.13239},
-archivePrefix = {arXiv},
-       eprint = {2502.13239},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250213239J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Malandrino:2025,
-       author = {{Malandrino}, Rosa and {Lavaux}, Guilhem and {Wandelt}, Benjamin D. and {McAlpine}, Stuart and {Jasche}, Jens},
-        title = "{A Bayesian catalog of 100 high-significance voids in the Local Universe}",
-      journal = {arXiv e-prints},
-     keywords = {Cosmology and Nongalactic Astrophysics},
-         year = 2025,
-        month = jul,
-          eid = {arXiv:2507.06866},
-        pages = {arXiv:2507.06866},
-          doi = {10.48550/arXiv.2507.06866},
-archivePrefix = {arXiv},
-       eprint = {2507.06866},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250706866M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{McAlpine:2026,
-       author = {{McAlpine}, Stuart},
-        title = "{The Manticore-Local Cluster Catalogue: A Posterior Map of Massive Structures in the Nearby Universe}",
-      journal = {The Open Journal of Astrophysics},
-     keywords = {Cosmology and Nongalactic Astrophysics},
-         year = 2026,
-        month = mar,
-       volume = {9},
-        pages = {59142},
-          doi = {10.33232/001c.159142},
-archivePrefix = {arXiv},
-       eprint = {2510.16574},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2026OJAp....959142M},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Andrews:2026,
-       author = {{Andrews}, Adam and {Jasche}, Jens and {Lavaux}, Guilhem and {Coulton}, William and {Villaescusa-Navarro}, Francisco and {Baldi}, Marco and {Jamieson}, Drew and {Jung}, Gabriel and {Karagiannis}, Dionysios and {Leclercq}, Florent and {Liguori}, Michele and {Marinucci}, Marco and {Wandelt}, Benjamin},
-        title = "{Field-Level Inference of Primordial Non-Gaussianity with the Quijote Simulation Suite}",
-      journal = {arXiv e-prints},
-     keywords = {Cosmology and Nongalactic Astrophysics},
-         year = 2026,
-        month = mar,
-          eid = {arXiv:2603.20855},
-        pages = {arXiv:2603.20855},
-          doi = {10.48550/arXiv.2603.20855},
-archivePrefix = {arXiv},
-       eprint = {2603.20855},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260320855A},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Stiskalek:2025,
-       author = {{Stiskalek}, Richard and {Desmond}, Harry and {Devriendt}, Julien and {Slyz}, Adrianne and {Lavaux}, Guilhem and {Hudson}, Michael J. and {Bartlett}, Deaglan J. and {Courtois}, H{\'e}l{\`e}ne M.},
-        title = "{The Velocity Field Olympics: assessing velocity field reconstructions with direct distance tracers}",
-      journal = {\mnras},
-     keywords = {galaxies: distances and redshifts, distance scale, large-scale structure of Universe, Cosmology and Nongalactic Astrophysics},
-         year = 2026,
-        month = jan,
-       volume = {545},
-       number = {2},
-          eid = {staf1960},
-        pages = {staf1960},
-          doi = {10.1093/mnras/staf1960},
-archivePrefix = {arXiv},
-       eprint = {2502.00121},
- primaryClass = {astro-ph.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2026MNRAS.545f1960S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{McAlpine:2026b,
-       author = {{McAlpine}, Stuart and {Jasche}, Jens and {Lavaux}, Guilhem and {Doeser}, Ludvig and {Loureiro}, Arthur},
-        title = "{The Manticore Project II: Bayesian digital twins of cosmic structure across the SDSS and BOSS volumes}",
-      journal = {submitted to MNRAS},
-     keywords = {Cosmology and Nongalactic Astrophysics},
-         year = 2026,
-        month = may,
-}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /publications/
 title: publications
-description: Collaboration related publications for 2023-2024
+description: Collaboration related publications for 2023-2026
 nav: true
 nav_order: 5
 ---


### PR DESCRIPTION
The LtU publication list is completely redone with this push. All papers are selected from ADS with the requirement that:
(1) The lead author is an LtU member
(2) At least 50% of authors must be LtU members
(3) There must be at least 2 LtU members on publication
(4) There must be an LtU working group co-leader on the publication
This is not perfect (it includes a few non-LtU publications and misses a number) but is much better than previous approach and is now automated.
