### PR TITLE
Change favicon from emoji to site logo image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ footer_text: >
 
 keywords: cosmology, machine learning, galaxy formation, implicit inference # add your own keywords or leave empty
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
-icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
+icon: icon.jpg # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
 url: https://learning-the-universe.github.io # the base hostname & protocol for your site
 baseurl: # the subpath of your site, e.g. /blog/. Leave blank for root


### PR DESCRIPTION
Replaces the default atom emoji favicon with the collaboration simulation image (assets/img/icon.jpg).